### PR TITLE
Use if and ranges for comparison

### DIFF
--- a/src/main/java/dev/blaauwendraad/masker/json/util/AsciiJsonUtil.java
+++ b/src/main/java/dev/blaauwendraad/masker/json/util/AsciiJsonUtil.java
@@ -21,92 +21,29 @@ import static dev.blaauwendraad.masker.json.util.AsciiCharacter.UPPERCASE_E;
 import static dev.blaauwendraad.masker.json.util.AsciiCharacter.ZERO;
 
 public final class AsciiJsonUtil {
-    static byte[] whiteSpaceCharacters = new byte[] {
-            CARRIAGE_RETURN.getAsciiByteValue(),
-            HORIZONTAL_TAB.getAsciiByteValue(),
-            LINE_FEED.getAsciiByteValue(),
-            SPACE.getAsciiByteValue()
-    };
-
-    /**
-     * Json number value can start with '-' or any digit 0-9
-     */
-    static byte[] firstNumberCharacters = new byte[] {
-            MINUS.getAsciiByteValue(),
-            ZERO.getAsciiByteValue(),
-            ONE.getAsciiByteValue(),
-            TWO.getAsciiByteValue(),
-            THREE.getAsciiByteValue(),
-            FOUR.getAsciiByteValue(),
-            FIVE.getAsciiByteValue(),
-            SIX.getAsciiByteValue(),
-            SEVEN.getAsciiByteValue(),
-            EIGHT.getAsciiByteValue(),
-            NINE.getAsciiByteValue()
-    };
-
-    /**
-     * Json numbers can include characters: '-', '+', '.', 'e', 'E', and digits 0-9
-     */
-    static byte[] numberCharacters = new byte[] {
-            MINUS.getAsciiByteValue(),
-            PLUS.getAsciiByteValue(),
-            PERIOD.getAsciiByteValue(),
-            LOWERCASE_E.getAsciiByteValue(),
-            UPPERCASE_E.getAsciiByteValue(),
-            ZERO.getAsciiByteValue(),
-            ONE.getAsciiByteValue(),
-            TWO.getAsciiByteValue(),
-            THREE.getAsciiByteValue(),
-            FOUR.getAsciiByteValue(),
-            FIVE.getAsciiByteValue(),
-            SIX.getAsciiByteValue(),
-            SEVEN.getAsciiByteValue(),
-            EIGHT.getAsciiByteValue(),
-            NINE.getAsciiByteValue()
-    };
 
     private AsciiJsonUtil() {
         // don't instantiate
     }
-
-    static byte[] firstNumberCharacters() {
-        return firstNumberCharacters;
-    }
-
-    static byte[] numberCharacters() {
-        return numberCharacters;
-    }
-
-    static byte[] whiteSpaces() {
-        return whiteSpaceCharacters;
-    }
-
     public static boolean isWhiteSpace(byte utf8Character) {
-        for (byte whiteSpaceChar : whiteSpaces()) {
-            if (utf8Character == whiteSpaceChar) {
-                return true;
-            }
-        }
-        return false;
+        return utf8Character == CARRIAGE_RETURN.getAsciiByteValue()
+                || utf8Character == HORIZONTAL_TAB.getAsciiByteValue()
+                || utf8Character == LINE_FEED.getAsciiByteValue()
+                || utf8Character == SPACE.getAsciiByteValue();
     }
 
     public static boolean isFirstNumberChar(byte utf8Character) {
-        for (byte firstNumberChar : firstNumberCharacters()) {
-            if (utf8Character == firstNumberChar) {
-                return true;
-            }
-        }
-        return false;
+        return (utf8Character >= ZERO.getAsciiByteValue() && utf8Character <= NINE.getAsciiByteValue())
+                || utf8Character == MINUS.getAsciiByteValue();
     }
 
     public static boolean isNumericCharacter(byte utf8Character) {
-        for (byte numberChar : numberCharacters()) {
-            if (utf8Character == numberChar) {
-                return true;
-            }
-        }
-        return false;
+        return (utf8Character >= ZERO.getAsciiByteValue() && utf8Character <= NINE.getAsciiByteValue())
+                || utf8Character == MINUS.getAsciiByteValue()
+                || utf8Character == PLUS.getAsciiByteValue()
+                || utf8Character == PERIOD.getAsciiByteValue()
+                || utf8Character == LOWERCASE_E.getAsciiByteValue()
+                || utf8Character == UPPERCASE_E.getAsciiByteValue();
     }
 
     public static boolean isArrayStart(byte utf8Character) {


### PR DESCRIPTION
Before:
```text
Benchmark                             (jsonSize)  (maskedKeyProbability)  (obfuscationLength)   Mode  Cnt     Score     Error  Units
JsonMaskerBenchmark.jsonMaskerBytes        128kb                    0.01                 none  thrpt    4  3805,313 ± 146,149  ops/s
JsonMaskerBenchmark.jsonMaskerString       128kb                    0.01                 none  thrpt    4  3855,438 ±  70,639  ops/s
```

After:
```text
Benchmark                             (jsonSize)  (maskedKeyProbability)  (obfuscationLength)   Mode  Cnt     Score     Error  Units
JsonMaskerBenchmark.jsonMaskerBytes        128kb                    0.01                 none  thrpt    4  5726,239 ± 527,834  ops/s
JsonMaskerBenchmark.jsonMaskerString       128kb                    0.01                 none  thrpt    4  5594,361 ± 756,827  ops/s
```

I have rerun it multiple times and got +- same results, though it is strange that this can give such a result