### PR TITLE
Store replacement operations in order to do a single array resize

### DIFF
--- a/src/jmh/benchmark-history/2024-01-03.md
+++ b/src/jmh/benchmark-history/2024-01-03.md
@@ -1,0 +1,88 @@
+- OS: Windows 11
+- CPU: AMD Ryzen 5 7600X
+- Java: 17.0.7
+
+```text
+Benchmark                                  (characters)  (jsonSize)  (maskedKeyProbability)  (obfuscationLength)   Mode  Cnt        Score   Error  Units
+BaselineBenchmark.countBytes                    unicode         1kb                    0.01                  N/A  thrpt       4275859.921          ops/s
+BaselineBenchmark.countBytes                    unicode       128kb                    0.01                  N/A  thrpt         34383.949          ops/s
+BaselineBenchmark.countBytes                    unicode         2mb                    0.01                  N/A  thrpt          2259.797          ops/s
+BaselineBenchmark.jacksonParseAndMask           unicode         1kb                    0.01                  N/A  thrpt         27694.585          ops/s
+BaselineBenchmark.jacksonParseAndMask           unicode       128kb                    0.01                  N/A  thrpt           164.931          ops/s
+BaselineBenchmark.jacksonParseAndMask           unicode         2mb                    0.01                  N/A  thrpt             7.827          ops/s
+BaselineBenchmark.regexReplace                  unicode         1kb                    0.01                  N/A  thrpt         26708.159          ops/s
+BaselineBenchmark.regexReplace                  unicode       128kb                    0.01                  N/A  thrpt            54.006          ops/s
+BaselineBenchmark.regexReplace                  unicode         2mb                    0.01                  N/A  thrpt             2.755          ops/s
+JsonMaskerBenchmark.jsonMaskerBytes    ascii (no quote)         1kb                    0.01                 none  thrpt       1792264.262          ops/s
+JsonMaskerBenchmark.jsonMaskerBytes    ascii (no quote)         1kb                    0.01                    8  thrpt       1313944.059          ops/s
+JsonMaskerBenchmark.jsonMaskerBytes    ascii (no quote)         1kb                     0.1                 none  thrpt       1422404.439          ops/s
+JsonMaskerBenchmark.jsonMaskerBytes    ascii (no quote)         1kb                     0.1                    8  thrpt       1305269.623          ops/s
+JsonMaskerBenchmark.jsonMaskerBytes    ascii (no quote)       128kb                    0.01                 none  thrpt          9573.676          ops/s
+JsonMaskerBenchmark.jsonMaskerBytes    ascii (no quote)       128kb                    0.01                    8  thrpt          9119.066          ops/s
+JsonMaskerBenchmark.jsonMaskerBytes    ascii (no quote)       128kb                     0.1                 none  thrpt          7618.644          ops/s
+JsonMaskerBenchmark.jsonMaskerBytes    ascii (no quote)       128kb                     0.1                    8  thrpt          7221.341          ops/s
+JsonMaskerBenchmark.jsonMaskerBytes    ascii (no quote)         2mb                    0.01                 none  thrpt           357.455          ops/s
+JsonMaskerBenchmark.jsonMaskerBytes    ascii (no quote)         2mb                    0.01                    8  thrpt           338.745          ops/s
+JsonMaskerBenchmark.jsonMaskerBytes    ascii (no quote)         2mb                     0.1                 none  thrpt           284.223          ops/s
+JsonMaskerBenchmark.jsonMaskerBytes    ascii (no quote)         2mb                     0.1                    8  thrpt           273.050          ops/s
+JsonMaskerBenchmark.jsonMaskerBytes               ascii         1kb                    0.01                 none  thrpt       1858309.486          ops/s
+JsonMaskerBenchmark.jsonMaskerBytes               ascii         1kb                    0.01                    8  thrpt       1883325.143          ops/s
+JsonMaskerBenchmark.jsonMaskerBytes               ascii         1kb                     0.1                 none  thrpt       1651683.564          ops/s
+JsonMaskerBenchmark.jsonMaskerBytes               ascii         1kb                     0.1                    8  thrpt       1490008.942          ops/s
+JsonMaskerBenchmark.jsonMaskerBytes               ascii       128kb                    0.01                 none  thrpt          8877.256          ops/s
+JsonMaskerBenchmark.jsonMaskerBytes               ascii       128kb                    0.01                    8  thrpt          9245.834          ops/s
+JsonMaskerBenchmark.jsonMaskerBytes               ascii       128kb                     0.1                 none  thrpt          7140.845          ops/s
+JsonMaskerBenchmark.jsonMaskerBytes               ascii       128kb                     0.1                    8  thrpt          7070.087          ops/s
+JsonMaskerBenchmark.jsonMaskerBytes               ascii         2mb                    0.01                 none  thrpt           318.472          ops/s
+JsonMaskerBenchmark.jsonMaskerBytes               ascii         2mb                    0.01                    8  thrpt           294.401          ops/s
+JsonMaskerBenchmark.jsonMaskerBytes               ascii         2mb                     0.1                 none  thrpt           260.596          ops/s
+JsonMaskerBenchmark.jsonMaskerBytes               ascii         2mb                     0.1                    8  thrpt           265.359          ops/s
+JsonMaskerBenchmark.jsonMaskerBytes             unicode         1kb                    0.01                 none  thrpt       2138407.873          ops/s
+JsonMaskerBenchmark.jsonMaskerBytes             unicode         1kb                    0.01                    8  thrpt       2127804.081          ops/s
+JsonMaskerBenchmark.jsonMaskerBytes             unicode         1kb                     0.1                 none  thrpt       1381401.814          ops/s
+JsonMaskerBenchmark.jsonMaskerBytes             unicode         1kb                     0.1                    8  thrpt       1384189.868          ops/s
+JsonMaskerBenchmark.jsonMaskerBytes             unicode       128kb                    0.01                 none  thrpt         10542.554          ops/s
+JsonMaskerBenchmark.jsonMaskerBytes             unicode       128kb                    0.01                    8  thrpt         11424.885          ops/s
+JsonMaskerBenchmark.jsonMaskerBytes             unicode       128kb                     0.1                 none  thrpt          8629.352          ops/s
+JsonMaskerBenchmark.jsonMaskerBytes             unicode       128kb                     0.1                    8  thrpt          8793.130          ops/s
+JsonMaskerBenchmark.jsonMaskerBytes             unicode         2mb                    0.01                 none  thrpt           355.040          ops/s
+JsonMaskerBenchmark.jsonMaskerBytes             unicode         2mb                    0.01                    8  thrpt           368.212          ops/s
+JsonMaskerBenchmark.jsonMaskerBytes             unicode         2mb                     0.1                 none  thrpt           321.465          ops/s
+JsonMaskerBenchmark.jsonMaskerBytes             unicode         2mb                     0.1                    8  thrpt           319.582          ops/s
+JsonMaskerBenchmark.jsonMaskerString   ascii (no quote)         1kb                    0.01                 none  thrpt       1470412.314          ops/s
+JsonMaskerBenchmark.jsonMaskerString   ascii (no quote)         1kb                    0.01                    8  thrpt       1485375.977          ops/s
+JsonMaskerBenchmark.jsonMaskerString   ascii (no quote)         1kb                     0.1                 none  thrpt       1185281.574          ops/s
+JsonMaskerBenchmark.jsonMaskerString   ascii (no quote)         1kb                     0.1                    8  thrpt       1231779.971          ops/s
+JsonMaskerBenchmark.jsonMaskerString   ascii (no quote)       128kb                    0.01                 none  thrpt          8046.371          ops/s
+JsonMaskerBenchmark.jsonMaskerString   ascii (no quote)       128kb                    0.01                    8  thrpt          7803.398          ops/s
+JsonMaskerBenchmark.jsonMaskerString   ascii (no quote)       128kb                     0.1                 none  thrpt          6908.720          ops/s
+JsonMaskerBenchmark.jsonMaskerString   ascii (no quote)       128kb                     0.1                    8  thrpt          6355.124          ops/s
+JsonMaskerBenchmark.jsonMaskerString   ascii (no quote)         2mb                    0.01                 none  thrpt           293.422          ops/s
+JsonMaskerBenchmark.jsonMaskerString   ascii (no quote)         2mb                    0.01                    8  thrpt           290.657          ops/s
+JsonMaskerBenchmark.jsonMaskerString   ascii (no quote)         2mb                     0.1                 none  thrpt           243.733          ops/s
+JsonMaskerBenchmark.jsonMaskerString   ascii (no quote)         2mb                     0.1                    8  thrpt           237.551          ops/s
+JsonMaskerBenchmark.jsonMaskerString              ascii         1kb                    0.01                 none  thrpt       1355714.023          ops/s
+JsonMaskerBenchmark.jsonMaskerString              ascii         1kb                    0.01                    8  thrpt       1595173.224          ops/s
+JsonMaskerBenchmark.jsonMaskerString              ascii         1kb                     0.1                 none  thrpt       1563292.350          ops/s
+JsonMaskerBenchmark.jsonMaskerString              ascii         1kb                     0.1                    8  thrpt       1082396.539          ops/s
+JsonMaskerBenchmark.jsonMaskerString              ascii       128kb                    0.01                 none  thrpt          7069.302          ops/s
+JsonMaskerBenchmark.jsonMaskerString              ascii       128kb                    0.01                    8  thrpt          7414.311          ops/s
+JsonMaskerBenchmark.jsonMaskerString              ascii       128kb                     0.1                 none  thrpt          5834.648          ops/s
+JsonMaskerBenchmark.jsonMaskerString              ascii       128kb                     0.1                    8  thrpt          6465.854          ops/s
+JsonMaskerBenchmark.jsonMaskerString              ascii         2mb                    0.01                 none  thrpt           267.409          ops/s
+JsonMaskerBenchmark.jsonMaskerString              ascii         2mb                    0.01                    8  thrpt           257.608          ops/s
+JsonMaskerBenchmark.jsonMaskerString              ascii         2mb                     0.1                 none  thrpt           227.994          ops/s
+JsonMaskerBenchmark.jsonMaskerString              ascii         2mb                     0.1                    8  thrpt           231.926          ops/s
+JsonMaskerBenchmark.jsonMaskerString            unicode         1kb                    0.01                 none  thrpt        640918.545          ops/s
+JsonMaskerBenchmark.jsonMaskerString            unicode         1kb                    0.01                    8  thrpt        577299.783          ops/s
+JsonMaskerBenchmark.jsonMaskerString            unicode         1kb                     0.1                 none  thrpt        460062.435          ops/s
+JsonMaskerBenchmark.jsonMaskerString            unicode         1kb                     0.1                    8  thrpt        515966.893          ops/s
+JsonMaskerBenchmark.jsonMaskerString            unicode       128kb                    0.01                 none  thrpt          2366.147          ops/s
+JsonMaskerBenchmark.jsonMaskerString            unicode       128kb                    0.01                    8  thrpt          2425.744          ops/s
+JsonMaskerBenchmark.jsonMaskerString            unicode       128kb                     0.1                 none  thrpt          2383.124          ops/s
+JsonMaskerBenchmark.jsonMaskerString            unicode       128kb                     0.1                    8  thrpt          2334.245          ops/s
+JsonMaskerBenchmark.jsonMaskerString            unicode         2mb                    0.01                 none  thrpt           140.958          ops/s
+JsonMaskerBenchmark.jsonMaskerString            unicode         2mb                    0.01                    8  thrpt           142.609          ops/s
+JsonMaskerBenchmark.jsonMaskerString            unicode         2mb                     0.1                 none  thrpt           138.359          ops/s
+JsonMaskerBenchmark.jsonMaskerString            unicode         2mb                     0.1                    8  thrpt           139.073          ops/s
+```

--- a/src/main/java/dev/blaauwendraad/masker/json/KeyContainsMasker.java
+++ b/src/main/java/dev/blaauwendraad/masker/json/KeyContainsMasker.java
@@ -3,7 +3,7 @@ package dev.blaauwendraad.masker.json;
 import dev.blaauwendraad.masker.json.config.JsonMaskingConfig;
 import dev.blaauwendraad.masker.json.util.AsciiCharacter;
 import dev.blaauwendraad.masker.json.util.AsciiJsonUtil;
-import dev.blaauwendraad.masker.json.util.FixedLengthTargetValueMaskUtil;
+import dev.blaauwendraad.masker.json.util.ValueMaskingUtil;
 import dev.blaauwendraad.masker.json.util.Utf8Util;
 
 import static dev.blaauwendraad.masker.json.util.AsciiCharacter.isDoubleQuote;
@@ -149,7 +149,7 @@ public final class KeyContainsMasker implements JsonMasker {
             }
         }
 
-        FixedLengthTargetValueMaskUtil.flushReplacementOperations(maskingState);
+        ValueMaskingUtil.flushReplacementOperations(maskingState);
 
         return maskingState.getMessage();
     }
@@ -255,7 +255,7 @@ public final class KeyContainsMasker implements JsonMasker {
              */
             maskLength = targetValueLength - noOfEscapeCharacters - additionalBytesForEncoding;
         }
-        FixedLengthTargetValueMaskUtil.replaceTargetValueWithFixedLengthAsteriskMask(
+        ValueMaskingUtil.replaceTargetValueWithFixedLengthAsteriskMask(
                 maskingState,
                 maskLength,
                 targetValueLength
@@ -378,7 +378,7 @@ public final class KeyContainsMasker implements JsonMasker {
         if (maskingConfig.isLengthObfuscationEnabled()) {
             maskLength = obfuscationLength > 0 ? obfuscationLength : 1;
         }
-        FixedLengthTargetValueMaskUtil.replaceTargetValueWithFixedLengthMask(
+        ValueMaskingUtil.replaceTargetValueWithFixedLengthMask(
                 maskingState,
                 maskLength,
                 targetValueLength,

--- a/src/main/java/dev/blaauwendraad/masker/json/KeyContainsMasker.java
+++ b/src/main/java/dev/blaauwendraad/masker/json/KeyContainsMasker.java
@@ -381,25 +381,22 @@ public final class KeyContainsMasker implements JsonMasker {
         int targetValueLength = 0;
         while (AsciiJsonUtil.isNumericCharacter(maskingState.byteAtCurrentIndex())) {
             targetValueLength++;
-            maskingState.setByteAtCurrentIndex(AsciiCharacter.toAsciiByteValue(maskingConfig.getMaskNumericValuesWith()));
             /*
              * Following line cannot result in ArrayOutOfBound because of the early return after checking for
              * first char being a double quote.
              */
             maskingState.incrementCurrentIndex();
         }
-        if (maskingConfig.isLengthObfuscationEnabled() && obfuscationLength != targetValueLength) {
-            FixedLengthTargetValueMaskUtil.replaceTargetValueWithFixedLengthMask(
-                    maskingState,
-                    /*
-                     For obfuscation length 0, we want to obfuscate numeric values with a single 0 because an
-                     empty numeric value is illegal JSON.
-                     */
-                    obfuscationLength > 0 ? obfuscationLength : 1,
-                    targetValueLength,
-                    AsciiCharacter.toAsciiByteValue(maskingConfig.getMaskNumericValuesWith())
-            );
+        int maskLength = targetValueLength;
+        if (maskingConfig.isLengthObfuscationEnabled()) {
+            maskLength = obfuscationLength > 0 ? obfuscationLength : 1;
         }
+        FixedLengthTargetValueMaskUtil.replaceTargetValueWithFixedLengthMask(
+                maskingState,
+                maskLength,
+                targetValueLength,
+                AsciiCharacter.toAsciiByteValue(maskingConfig.getMaskNumericValuesWith())
+        );
     }
 
     /**

--- a/src/main/java/dev/blaauwendraad/masker/json/KeyContainsMasker.java
+++ b/src/main/java/dev/blaauwendraad/masker/json/KeyContainsMasker.java
@@ -242,37 +242,24 @@ public final class KeyContainsMasker implements JsonMasker {
             targetValueLength++;
             maskingState.incrementCurrentIndex();
         }
-        int obfuscationLength = maskingConfig.getObfuscationLength();
-        if (maskingConfig.isLengthObfuscationEnabled()
-                && obfuscationLength != targetValueLength) {
-            FixedLengthTargetValueMaskUtil.replaceTargetValueWithFixedLengthAsteriskMask(
-                    maskingState,
-                    obfuscationLength,
-                    targetValueLength
-            );
-        } else if (!maskingConfig.isLengthObfuscationEnabled() && (noOfEscapeCharacters > 0
-                || additionalBytesForEncoding > 0)) {
-            // So we don't add asterisks for escape characters or additional encoding bytes (which
-            // are not part of the String length)
-
+        int maskLength = targetValueLength;
+        if (maskingConfig.isLengthObfuscationEnabled()) {
+            maskLength = maskingConfig.getObfuscationLength();
+        } else if (noOfEscapeCharacters > 0 || additionalBytesForEncoding > 0) {
             /*
-             * The actual length of the string is the length minus escape characters (which are not part of the
-             * string length). Also, unicode characters are denoted as 4-hex digits but represent actually
-             * just one character, so for each of them 3 asterisks should be removed.
+            So we don't add asterisks for escape characters or additional encoding bytes (which are not part of the String length)
+
+            The actual length of the string is the length minus escape characters (which are not part of the
+            string length). Also, unicode characters are denoted as 4-hex digits but represent actually
+            just one character, so for each of them 3 asterisks should be removed.
              */
-            int actualStringLength = targetValueLength - noOfEscapeCharacters - additionalBytesForEncoding;
-            FixedLengthTargetValueMaskUtil.replaceTargetValueWithFixedLengthAsteriskMask(
-                    maskingState,
-                    actualStringLength,
-                    targetValueLength
-            );
-        } else {
-            FixedLengthTargetValueMaskUtil.replaceTargetValueWithFixedLengthAsteriskMask(
-                    maskingState,
-                    targetValueLength,
-                    targetValueLength
-            );
+            maskLength = targetValueLength - noOfEscapeCharacters - additionalBytesForEncoding;
         }
+        FixedLengthTargetValueMaskUtil.replaceTargetValueWithFixedLengthAsteriskMask(
+                maskingState,
+                maskLength,
+                targetValueLength
+        );
         maskingState.incrementCurrentIndex(); // step over closing quote of string value to start looking for the next JSON key.
     }
 

--- a/src/main/java/dev/blaauwendraad/masker/json/MaskingState.java
+++ b/src/main/java/dev/blaauwendraad/masker/json/MaskingState.java
@@ -34,10 +34,6 @@ public final class MaskingState {
         return message[currentIndex];
     }
 
-    public void setByteAtCurrentIndex(byte newByte) {
-        message[currentIndex] = newByte;
-    }
-
     public byte byteAtCurrentIndexMinusOne() {
         return message[currentIndex - 1];
     }

--- a/src/main/java/dev/blaauwendraad/masker/json/MaskingState.java
+++ b/src/main/java/dev/blaauwendraad/masker/json/MaskingState.java
@@ -10,7 +10,7 @@ import java.util.List;
 public final class MaskingState {
     private byte[] message;
     private int currentIndex;
-    private List<ReplacementOperation> replacementOperations = new ArrayList<>();
+    private final List<ReplacementOperation> replacementOperations = new ArrayList<>();
     private int replacementOperationsTotalDifference = 0;
 
     public MaskingState(byte[] message, int currentIndex) {

--- a/src/main/java/dev/blaauwendraad/masker/json/MaskingState.java
+++ b/src/main/java/dev/blaauwendraad/masker/json/MaskingState.java
@@ -1,5 +1,8 @@
 package dev.blaauwendraad.masker.json;
 
+import java.util.ArrayList;
+import java.util.List;
+
 /**
  * Represents the state of the {@link JsonMasker} at a given point in time during the {@link JsonMasker#mask(byte[])}
  * operation.
@@ -7,6 +10,8 @@ package dev.blaauwendraad.masker.json;
 public final class MaskingState {
     private byte[] message;
     private int currentIndex;
+    private List<ReplacementOperation> replacementOperations = new ArrayList<>();
+    private int replacementOperationsTotalDifference = 0;
 
     public MaskingState(byte[] message, int currentIndex) {
         this.message = message;
@@ -49,10 +54,32 @@ public final class MaskingState {
         return message;
     }
 
+    public void addReplacementOperation(int startIndex, int endIndex, int maskLength, byte maskByte) {
+        ReplacementOperation replacementOperation = new ReplacementOperation(startIndex, endIndex, maskLength, maskByte);
+        replacementOperations.add(replacementOperation);
+        replacementOperationsTotalDifference += replacementOperation.difference();
+    }
+
+    public List<ReplacementOperation> getReplacementOperations() {
+        return replacementOperations;
+    }
+
     // for debugging purposes, shows the current state of message traversal
-    public String peek() {
+    @Override
+    public String toString() {
         return "current: '" + (currentIndex == message.length ? "<end of json>" : (char) message[currentIndex]) + "'," +
                 " before: '" + new String(message, Math.max(0, currentIndex - 10), Math.min(10, currentIndex)) + "'," +
                 " after: '" + new String(message, currentIndex, Math.min(10, message.length - currentIndex)) + "'";
+    }
+
+    public int getReplacementOperationsTotalDifference() {
+        return replacementOperationsTotalDifference;
+    }
+
+    public record ReplacementOperation(int startIndex, int endIndex, int maskLength, byte maskByte) {
+
+        public int difference() {
+            return maskLength - (endIndex - startIndex);
+        }
     }
 }

--- a/src/main/java/dev/blaauwendraad/masker/json/MaskingState.java
+++ b/src/main/java/dev/blaauwendraad/masker/json/MaskingState.java
@@ -64,16 +64,16 @@ public final class MaskingState {
         return replacementOperations;
     }
 
+    public int getReplacementOperationsTotalDifference() {
+        return replacementOperationsTotalDifference;
+    }
+
     // for debugging purposes, shows the current state of message traversal
     @Override
     public String toString() {
         return "current: '" + (currentIndex == message.length ? "<end of json>" : (char) message[currentIndex]) + "'," +
                 " before: '" + new String(message, Math.max(0, currentIndex - 10), Math.min(10, currentIndex)) + "'," +
                 " after: '" + new String(message, currentIndex, Math.min(10, message.length - currentIndex)) + "'";
-    }
-
-    public int getReplacementOperationsTotalDifference() {
-        return replacementOperationsTotalDifference;
     }
 
     public record ReplacementOperation(int startIndex, int endIndex, int maskLength, byte maskByte) {

--- a/src/main/java/dev/blaauwendraad/masker/json/MaskingState.java
+++ b/src/main/java/dev/blaauwendraad/masker/json/MaskingState.java
@@ -50,16 +50,25 @@ public final class MaskingState {
         return message;
     }
 
+    /**
+     * Adds new delayed replacement operation to the list of operations to be applied to the message.
+     */
     public void addReplacementOperation(int startIndex, int endIndex, int maskLength, byte maskByte) {
         ReplacementOperation replacementOperation = new ReplacementOperation(startIndex, endIndex, maskLength, maskByte);
         replacementOperations.add(replacementOperation);
         replacementOperationsTotalDifference += replacementOperation.difference();
     }
 
+    /**
+     * Returns the list of replacement operations that need to be applied to the message.
+     */
     public List<ReplacementOperation> getReplacementOperations() {
         return replacementOperations;
     }
 
+    /**
+     * Returns the total difference between the masks and target values lengths of all replacement operations.
+     */
     public int getReplacementOperationsTotalDifference() {
         return replacementOperationsTotalDifference;
     }
@@ -72,8 +81,22 @@ public final class MaskingState {
                 " after: '" + new String(message, currentIndex, Math.min(10, message.length - currentIndex)) + "'";
     }
 
+    /**
+     * Represents a delayed replacement that requires resizing of the message byte array. In order to avoid resizing on
+     * every mask, we store the replacement operations in a list and apply them all at once at the end, thus making only
+     * a single resize operation.
+     *
+     * @param startIndex index from which to start replacing
+     * @param endIndex   index at which to stop replacing
+     * @param maskLength length of the mask to apply
+     * @param maskByte   byte to use for the mask
+     */
     public record ReplacementOperation(int startIndex, int endIndex, int maskLength, byte maskByte) {
 
+        /**
+         * The difference between the mask length and the length of the target value to replace.
+         * Used to calculate keep track of the offset during replacements.
+         */
         public int difference() {
             return maskLength - (endIndex - startIndex);
         }

--- a/src/main/java/dev/blaauwendraad/masker/json/util/FixedLengthTargetValueMaskUtil.java
+++ b/src/main/java/dev/blaauwendraad/masker/json/util/FixedLengthTargetValueMaskUtil.java
@@ -2,6 +2,8 @@ package dev.blaauwendraad.masker.json.util;
 
 import dev.blaauwendraad.masker.json.MaskingState;
 
+import java.util.Arrays;
+
 /**
  * Class containing utility methods to set a particular target value length to a fixed size mask. This can be used for
  * length obfuscation and ignoring escaping characters in string values.
@@ -15,47 +17,95 @@ public final class FixedLengthTargetValueMaskUtil {
      * Replaces a target value (byte slice) with a fixed length string consisting only of the mask bytes inside the
      * input bytes array.
      *
-     * @param fixedMaskLength   the length of the fixed-length mask byte string.
+     * @param maskLength        the length of the fixed-length mask byte string.
      * @param targetValueLength the length of the target value slice.
      * @param maskByte          the byte used for each byte in the mask
      */
     public static void replaceTargetValueWithFixedLengthMask(
             MaskingState maskingState,
-            int fixedMaskLength,
+            int maskLength,
             int targetValueLength,
             byte maskByte
     ) {
-        // Create new empty array with a length computed by the difference between requested fixed length and target
-        // value length.
-        byte[] newInputBytes = new byte[maskingState.getMessage().length + (fixedMaskLength - targetValueLength)];
+        int lengthDifference = maskLength - targetValueLength;
         int targetValueStartIndex = maskingState.currentIndex() - targetValueLength;
-        // Copy all bytes till the target value (including opening quotes of the string value to be replaced)
-        System.arraycopy(maskingState.getMessage(), 0, newInputBytes, 0, targetValueStartIndex);
-        // Start from beginning of target value and loop amount of required masked characters
-        for (int i = targetValueStartIndex; i < targetValueStartIndex + fixedMaskLength; i++) {
-            newInputBytes[i] = maskByte; // add masking characters
+        if (lengthDifference == 0) {
+            Arrays.fill(maskingState.getMessage(), targetValueStartIndex, maskingState.currentIndex(), maskByte);
+            return;
         }
-        // Append the rest of the original array starting from end of target value
-        System.arraycopy(
-                maskingState.getMessage(),
-                maskingState.currentIndex(),
-                newInputBytes,
-                targetValueStartIndex + fixedMaskLength,
-                maskingState.getMessage().length - maskingState.currentIndex()
-        );
-        maskingState.setMessage(newInputBytes);
+        maskingState.addReplacementOperation(targetValueStartIndex, maskingState.currentIndex(), maskLength, maskByte);
     }
 
     public static void replaceTargetValueWithFixedLengthAsteriskMask(
             MaskingState maskingState,
-            int fixedLength,
+            int maskLength,
             int targetValueLength
     ) {
         replaceTargetValueWithFixedLengthMask(
                 maskingState,
-                fixedLength,
+                maskLength,
                 targetValueLength,
                 AsciiCharacter.ASTERISK.getAsciiByteValue()
         );
+    }
+
+    /**
+     * Performs all replacement operations to the message array, must be called at the end of the replacements.
+     * <p>
+     * For every operation that required resizing of the original array, to avoid copying the array multiple times,
+     * those operations were stored in a list and can be performed in one go, thus resizing the array only once.
+     * <p>
+     * Replacement operation is only recorded if the length of the target value is different from the length of the mask,
+     * otherwise the replacement must have been done in-place.
+     *
+     * @param maskingState the current state of the {@link dev.blaauwendraad.masker.json.JsonMasker} instance.
+     */
+    public static void flushReplacementOperations(MaskingState maskingState) {
+        if (maskingState.getReplacementOperations().isEmpty()) {
+            return;
+        }
+
+        // Create new empty array with a length computed by the difference of all mismatches of lengths between the target values and the masks
+        // in some edge cases the length difference might be equal to 0, but since some indices mismatch (otherwise there would be no replacement operations)
+        // we still have to copy the array to keep track of data according to original indices
+        byte[] newMessage = new byte[maskingState.getMessage().length + maskingState.getReplacementOperationsTotalDifference()];
+
+        // Index of the original message array
+        int index = 0;
+        // Offset is the difference between the original and new array indices, we need it to calculate indices
+        // in the new message array using startIndex and endIndex, which are indices in the original array
+        int offset = 0;
+        for (MaskingState.ReplacementOperation replacementOperation : maskingState.getReplacementOperations()) {
+            // Copy everything from message up until replacement operation start index
+            System.arraycopy(
+                    maskingState.getMessage(),
+                    index,
+                    newMessage,
+                    index + offset,
+                    replacementOperation.startIndex() - index
+            );
+            // Insert the mask bytes
+            Arrays.fill(
+                    newMessage,
+                    replacementOperation.startIndex() + offset,
+                    replacementOperation.startIndex() + offset + replacementOperation.maskLength(),
+                    replacementOperation.maskByte()
+            );
+            // Adjust index and offset to continue copying from the end of the replacement operation
+            index = replacementOperation.endIndex();
+            offset += replacementOperation.difference();
+        }
+
+        // Copy the remainder of the original array
+        System.arraycopy(
+                maskingState.getMessage(),
+                index,
+                newMessage,
+                index + offset,
+                maskingState.getMessage().length - index
+        );
+
+        maskingState.setMessage(newMessage);
+        maskingState.setCurrentIndex(newMessage.length);
     }
 }

--- a/src/main/java/dev/blaauwendraad/masker/json/util/ValueMaskingUtil.java
+++ b/src/main/java/dev/blaauwendraad/masker/json/util/ValueMaskingUtil.java
@@ -5,17 +5,18 @@ import dev.blaauwendraad.masker.json.MaskingState;
 import java.util.Arrays;
 
 /**
- * Class containing utility methods to set a particular target value length to a fixed size mask. This can be used for
+ * Class containing utility methods to replace a particular target value with a mask. This can be used for
  * length obfuscation and ignoring escaping characters in string values.
  */
-public final class FixedLengthTargetValueMaskUtil {
-    private FixedLengthTargetValueMaskUtil() {
+public final class ValueMaskingUtil {
+    private ValueMaskingUtil() {
         // util
     }
 
     /**
-     * Replaces a target value (byte slice) with a fixed length string consisting only of the mask bytes inside the
-     * input bytes array.
+     * Replaces a target value (byte slice) with a mask byte. If lengths of both target value and mask are equal, the
+     * replacement is done in-place, otherwise a replacement operation is recorded to be performed as a batch using
+     * {@link #flushReplacementOperations}.
      *
      * @param maskLength        the length of the fixed-length mask byte string.
      * @param targetValueLength the length of the target value slice.


### PR DESCRIPTION
### Benchmark results (`./gradlew jmh -PjmhShort`):
Before:
```
Benchmark                                  (characters)  (jsonSize)  (maskedKeyProbability)  (obfuscationLength)   Mode  Cnt      Score     Error  Units
BaselineBenchmark.countBytes                    unicode       128kb                    0.01                  N/A  thrpt    4  34250.391 ▒ 420.174  ops/s
BaselineBenchmark.jacksonParseAndMask           unicode       128kb                    0.01                  N/A  thrpt    4    165.091 ▒   5.335  ops/s
BaselineBenchmark.regexReplace                  unicode       128kb                    0.01                  N/A  thrpt    4     51.704 ▒   3.354  ops/s
JsonMaskerBenchmark.jsonMaskerBytes    ascii (no quote)       128kb                    0.01                 none  thrpt    4   9915.660 ▒ 425.860  ops/s
JsonMaskerBenchmark.jsonMaskerBytes               ascii       128kb                    0.01                 none  thrpt    4   9305.348 ▒  62.295  ops/s
JsonMaskerBenchmark.jsonMaskerBytes             unicode       128kb                    0.01                 none  thrpt    4  12057.404 ▒ 419.343  ops/s
JsonMaskerBenchmark.jsonMaskerString   ascii (no quote)       128kb                    0.01                 none  thrpt    4   7925.503 ▒ 160.098  ops/s
JsonMaskerBenchmark.jsonMaskerString              ascii       128kb                    0.01                 none  thrpt    4   8053.798 ▒ 615.886  ops/s
JsonMaskerBenchmark.jsonMaskerString            unicode       128kb                    0.01                 none  thrpt    4   1987.428 ▒  17.674  ops/s
```

After:
```

Benchmark                                  (characters)  (jsonSize)  (maskedKeyProbability)  (obfuscationLength)   Mode  Cnt      Score     Error  Units
BaselineBenchmark.countBytes                    unicode       128kb                    0.01                  N/A  thrpt    4  34271.957 ▒ 337.662  ops/s
BaselineBenchmark.jacksonParseAndMask           unicode       128kb                    0.01                  N/A  thrpt    4    164.577 ▒   3.481  ops/s
BaselineBenchmark.regexReplace                  unicode       128kb                    0.01                  N/A  thrpt    4     65.975 ▒   0.297  ops/s
JsonMaskerBenchmark.jsonMaskerBytes    ascii (no quote)       128kb                    0.01                 none  thrpt    4   9992.484 ▒  62.882  ops/s
JsonMaskerBenchmark.jsonMaskerBytes               ascii       128kb                    0.01                 none  thrpt    4   8901.443 ▒  95.178  ops/s
JsonMaskerBenchmark.jsonMaskerBytes             unicode       128kb                    0.01                 none  thrpt    4  11286.123 ▒ 382.730  ops/s
JsonMaskerBenchmark.jsonMaskerString   ascii (no quote)       128kb                    0.01                 none  thrpt    4   8400.088 ▒ 109.190  ops/s
JsonMaskerBenchmark.jsonMaskerString              ascii       128kb                    0.01                 none  thrpt    4   8762.854 ▒  56.332  ops/s
JsonMaskerBenchmark.jsonMaskerString            unicode       128kb                    0.01                 none  thrpt    4   2408.000 ▒ 114.824  ops/s
```

### And for 2mb json with obfuscation enabled:
Before:
```
Benchmark                                  (characters)  (jsonSize)  (maskedKeyProbability)  (obfuscationLength)   Mode  Cnt     Score    Error  Units
BaselineBenchmark.countBytes                    unicode         2mb                    0.01                  N/A  thrpt    4  2272.636 ▒ 26.388  ops/s
BaselineBenchmark.jacksonParseAndMask           unicode         2mb                    0.01                  N/A  thrpt    4     7.887 ▒  0.106  ops/s
BaselineBenchmark.regexReplace                  unicode         2mb                    0.01                  N/A  thrpt    4     2.789 ▒  0.047  ops/s
JsonMaskerBenchmark.jsonMaskerBytes    ascii (no quote)         2mb                    0.01                    8  thrpt    4    14.366 ▒  0.069  ops/s
JsonMaskerBenchmark.jsonMaskerBytes               ascii         2mb                    0.01                    8  thrpt    4    13.617 ▒  0.086  ops/s
JsonMaskerBenchmark.jsonMaskerBytes             unicode         2mb                    0.01                    8  thrpt    4    15.337 ▒  0.780  ops/s
JsonMaskerBenchmark.jsonMaskerString   ascii (no quote)         2mb                    0.01                    8  thrpt    4    13.793 ▒  0.051  ops/s
JsonMaskerBenchmark.jsonMaskerString              ascii         2mb                    0.01                    8  thrpt    4    14.024 ▒  0.200  ops/s
JsonMaskerBenchmark.jsonMaskerString            unicode         2mb                    0.01                    8  thrpt    4    17.142 ▒  0.441  ops/s
```

After:
```
Benchmark                                  (characters)  (jsonSize)  (maskedKeyProbability)  (obfuscationLength)   Mode  Cnt     Score    Error  Units
BaselineBenchmark.countBytes                    unicode         2mb                    0.01                  N/A  thrpt    4  2271.825 ▒ 16.711  ops/s
BaselineBenchmark.jacksonParseAndMask           unicode         2mb                    0.01                  N/A  thrpt    4     7.997 ▒  0.239  ops/s
BaselineBenchmark.regexReplace                  unicode         2mb                    0.01                  N/A  thrpt    4     4.517 ▒  0.134  ops/s
JsonMaskerBenchmark.jsonMaskerBytes    ascii (no quote)         2mb                    0.01                    8  thrpt    4   341.738 ▒  4.737  ops/s
JsonMaskerBenchmark.jsonMaskerBytes               ascii         2mb                    0.01                    8  thrpt    4   301.066 ▒  7.211  ops/s
JsonMaskerBenchmark.jsonMaskerBytes             unicode         2mb                    0.01                    8  thrpt    4   366.295 ▒ 18.235  ops/s
JsonMaskerBenchmark.jsonMaskerString   ascii (no quote)         2mb                    0.01                    8  thrpt    4   285.796 ▒  6.253  ops/s
JsonMaskerBenchmark.jsonMaskerString              ascii         2mb                    0.01                    8  thrpt    4   278.421 ▒  5.353  ops/s
JsonMaskerBenchmark.jsonMaskerString            unicode         2mb                    0.01                    8  thrpt    4   145.581 ▒  5.877  ops/s
```