### PR TITLE
Use fixed seed for benchmarks

### DIFF
--- a/src/jmh/java/dev/blaauwendraad/masker/json/BenchmarkUtils.java
+++ b/src/jmh/java/dev/blaauwendraad/masker/json/BenchmarkUtils.java
@@ -62,6 +62,7 @@ public class BenchmarkUtils {
                 .setTargetKeys(targetKeys)
                 .setTargetKeyPercentage(targetKeyPercentage)
                 .setTargetJsonSizeBytes(BenchmarkUtils.parseSize(jsonSize))
+                .setRandomSeed(1285756302517652226L)
                 .createConfig();
 
         return new RandomJsonGenerator(config).createRandomJsonNode().toString();

--- a/src/test/java/randomgen/json/RandomJsonGeneratorConfig.java
+++ b/src/test/java/randomgen/json/RandomJsonGeneratorConfig.java
@@ -23,6 +23,7 @@ public class RandomJsonGeneratorConfig {
     private final Set<Character> allowedCharacters;
     private final Set<String> targetKeys;
     private final int targetJsonSizeBytes;
+    private final long randomSeed;
 
     public RandomJsonGeneratorConfig(
             int maxArraySize,
@@ -36,7 +37,8 @@ public class RandomJsonGeneratorConfig {
             double targetKeyPercentage,
             Set<Character> allowedCharacters,
             Set<String> targetKeys,
-            int targetJsonSizeBytes
+            int targetJsonSizeBytes,
+            long randomSeed
     ) {
         this.maxArraySize = maxArraySize;
         this.maxFloat = maxFloat;
@@ -50,6 +52,7 @@ public class RandomJsonGeneratorConfig {
         this.targetKeys = targetKeys;
         this.maxStringLength = maxStringLength;
         this.targetJsonSizeBytes = targetJsonSizeBytes;
+        this.randomSeed = randomSeed;
     }
 
     public static Builder builder() {
@@ -120,6 +123,10 @@ public class RandomJsonGeneratorConfig {
         return targetJsonSizeBytes != -1;
     }
 
+    public long getRandomSeed() {
+        return randomSeed;
+    }
+
     public static class Builder {
         private int maxArraySize = 5;
         private float maxFloat = Float.MAX_VALUE;
@@ -137,6 +144,7 @@ public class RandomJsonGeneratorConfig {
         );
         private Set<String> targetKeys = defaultTargetKeys;
         private int targetJsonSizeBytes = -1; // no target, random size depending on other constraints
+        private long randomSeed = 0; // no seed, using the ThreadLocalRandom()
 
         public Builder setMaxArraySize(int maxArraySize) {
             this.maxArraySize = maxArraySize;
@@ -198,6 +206,11 @@ public class RandomJsonGeneratorConfig {
             return this;
         }
 
+        public Builder setRandomSeed(long randomSeed) {
+            this.randomSeed = randomSeed;
+            return this;
+        }
+
         public RandomJsonGeneratorConfig createConfig() {
             return new RandomJsonGeneratorConfig(
                     maxArraySize,
@@ -211,7 +224,8 @@ public class RandomJsonGeneratorConfig {
                     targetKeyPercentage,
                     allowedCharacters,
                     targetKeys,
-                    targetJsonSizeBytes
+                    targetJsonSizeBytes,
+                    randomSeed
             );
         }
     }

--- a/src/test/java/randomgen/json/RandomJsonGeneratorTest.java
+++ b/src/test/java/randomgen/json/RandomJsonGeneratorTest.java
@@ -19,8 +19,9 @@ public class RandomJsonGeneratorTest {
     @ValueSource(ints = 100)
     void testRandomGenerator(int numberOfTests) {
         for (int i = 0; i < numberOfTests; i++) {
-            RandomJsonGenerator randomJsonGenerator =
-                    new RandomJsonGenerator(RandomJsonGeneratorConfig.builder().createConfig());
+            RandomJsonGenerator randomJsonGenerator = new RandomJsonGenerator(
+                    RandomJsonGeneratorConfig.builder().createConfig()
+            );
             JsonNode randomJsonNode = randomJsonGenerator.createRandomJsonNode();
             System.out.println(randomJsonNode.toPrettyString());
         }
@@ -33,10 +34,11 @@ public class RandomJsonGeneratorTest {
             // let's start with at least 5kb json size, on smaller sizes (e.g. 1kb)
             // we risk having more than 1% difference due to requirement to return a valid json
             int targetJsonSizeBytes = (i + 5) * 1024;
-            RandomJsonGenerator randomJsonGenerator =
-                    new RandomJsonGenerator(RandomJsonGeneratorConfig.builder()
-                                                    .setTargetJsonSizeBytes(targetJsonSizeBytes)
-                                                    .createConfig());
+            RandomJsonGenerator randomJsonGenerator = new RandomJsonGenerator(
+                    RandomJsonGeneratorConfig.builder()
+                            .setTargetJsonSizeBytes(targetJsonSizeBytes)
+                            .createConfig()
+            );
 
             JsonNode randomJsonNode = randomJsonGenerator.createRandomJsonNode();
 
@@ -55,10 +57,11 @@ public class RandomJsonGeneratorTest {
     @Test
     void testGenerate1MbJson() {
         int targetJsonSizeBytes = 1024 * 1024;
-        RandomJsonGenerator randomJsonGenerator =
-                new RandomJsonGenerator(RandomJsonGeneratorConfig.builder()
-                                                .setTargetJsonSizeBytes(targetJsonSizeBytes)
-                                                .createConfig());
+        RandomJsonGenerator randomJsonGenerator = new RandomJsonGenerator(
+                RandomJsonGeneratorConfig.builder()
+                        .setTargetJsonSizeBytes(targetJsonSizeBytes)
+                        .createConfig()
+        );
 
         JsonNode randomJsonNode = randomJsonGenerator.createRandomJsonNode();
 
@@ -76,10 +79,11 @@ public class RandomJsonGeneratorTest {
     @Test
     void testGenerate10MbJson() {
         int targetJsonSizeBytes = 10 * 1024 * 1024;
-        RandomJsonGenerator randomJsonGenerator =
-                new RandomJsonGenerator(RandomJsonGeneratorConfig.builder()
-                                                .setTargetJsonSizeBytes(targetJsonSizeBytes)
-                                                .createConfig());
+        RandomJsonGenerator randomJsonGenerator = new RandomJsonGenerator(
+                RandomJsonGeneratorConfig.builder()
+                        .setTargetJsonSizeBytes(targetJsonSizeBytes)
+                        .createConfig()
+        );
 
         JsonNode randomJsonNode = randomJsonGenerator.createRandomJsonNode();
 
@@ -119,5 +123,55 @@ public class RandomJsonGeneratorTest {
         }
 
         System.out.println(size);
+    }
+
+    @Test
+    void shouldReturnIdenticalJsonsForTheSameSeed() {
+        RandomJsonGenerator randomJsonGenerator = new RandomJsonGenerator(
+                RandomJsonGeneratorConfig.builder()
+                        .setTargetJsonSizeBytes(10 * 1024)
+                        .setRandomSeed(1285756302517652226L)
+                        .createConfig()
+        );
+
+        String json1 = randomJsonGenerator.createRandomJsonNode().toString();
+        String json2 = randomJsonGenerator.createRandomJsonNode().toString();
+
+        Assertions.assertEquals(json1, json2);
+    }
+
+    @Test
+    void shouldReturnDifferentJsonsIfSeedIsNotSet() {
+        RandomJsonGenerator randomJsonGenerator = new RandomJsonGenerator(
+                RandomJsonGeneratorConfig.builder()
+                        .setTargetJsonSizeBytes(10 * 1024)
+                        .createConfig()
+        );
+
+        String json1 = randomJsonGenerator.createRandomJsonNode().toString();
+        String json2 = randomJsonGenerator.createRandomJsonNode().toString();
+
+        Assertions.assertNotEquals(json1, json2);
+    }
+
+    @Test
+    void shouldReturnDifferentJsonsForDifferentParameters() {
+        RandomJsonGenerator randomJsonGenerator1 = new RandomJsonGenerator(
+                RandomJsonGeneratorConfig.builder()
+                        .setTargetJsonSizeBytes(10 * 1024)
+                        .setRandomSeed(1285756302517652226L)
+                        .createConfig()
+        );
+        RandomJsonGenerator randomJsonGenerator2 = new RandomJsonGenerator(
+                RandomJsonGeneratorConfig.builder()
+                        .setTargetJsonSizeBytes(10 * 1024 + 100)
+                        .setRandomSeed(1285756302517652226L)
+                        .createConfig()
+        );
+
+        String json1 = randomJsonGenerator1.createRandomJsonNode().toString();
+        String json2 = randomJsonGenerator2.createRandomJsonNode().toString();
+
+        Assertions.assertNotEquals(json1, json2);
     }
 }


### PR DESCRIPTION
This PR adds configuration to set a seed for random json generation. Use it in benchmarks to make sure that results are consistent across the same generation options, so that the same `jsonSize` + `maskedKeyProbability` will always generate the same json.

Why are we using `1285756302517652226L`? I couldn't make myself betray `ThreadLocalRandom` and start using `Random` 🤮, so I at least used `ThreadLocalRandom` to generate this seed.