### PR TITLE
Remove try parse logic in FuzzingTest, reuse formatter in NoFailingExecutionFuzzingTest

### DIFF
--- a/src/test/java/dev/blaauwendraad/masker/json/FuzzingTest.java
+++ b/src/test/java/dev/blaauwendraad/masker/json/FuzzingTest.java
@@ -1,7 +1,7 @@
 package dev.blaauwendraad.masker.json;
 
-import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
 import dev.blaauwendraad.masker.json.config.JsonMaskingConfig;
 import dev.blaauwendraad.masker.json.path.JsonPath;
 import dev.blaauwendraad.masker.json.util.FuzzingDurationUtil;
@@ -40,15 +40,10 @@ final class FuzzingTest {
                 new RandomJsonGenerator(RandomJsonGeneratorConfig.builder().setTargetKeys(allKeys).createConfig());
         JsonMasker masker = JsonMasker.getMasker(jsonMaskingConfig);
         while (Duration.between(startTime, Instant.now()).toMillis() < timeLimit) {
+            JsonNode randomJsonNode = randomJsonGenerator.createRandomJsonNode();
             for (JsonFormatter formatter : JsonFormatter.values()) {
-                String randomJsonString = formatter.format(randomJsonGenerator.createRandomJsonNode());
-                String jacksonMaskingOutput;
-                try {
-                    jacksonMaskingOutput = ParseAndMaskUtil.mask(randomJsonString, jsonMaskingConfig).toString();
-                } catch (JsonParseException e) {
-                    // if jackson rejects it, then we don't test
-                    continue;
-                }
+                String randomJsonString = formatter.format(randomJsonNode);
+                String jacksonMaskingOutput = ParseAndMaskUtil.mask(randomJsonString, jsonMaskingConfig).toString();
                 try {
                     String keyContainsOutput = masker.mask(randomJsonString);
                     // parsing again by jackson to get canonical representation

--- a/src/test/java/dev/blaauwendraad/masker/json/NoFailingExecutionFuzzingTest.java
+++ b/src/test/java/dev/blaauwendraad/masker/json/NoFailingExecutionFuzzingTest.java
@@ -1,21 +1,17 @@
 package dev.blaauwendraad.masker.json;
 
-import static org.assertj.core.api.Assertions.fail;
-
 import com.fasterxml.jackson.databind.JsonNode;
 import dev.blaauwendraad.masker.json.config.JsonMaskingConfig;
-import dev.blaauwendraad.masker.json.util.AsciiJsonUtil;
-
 import dev.blaauwendraad.masker.json.util.FuzzingDurationUtil;
 import dev.blaauwendraad.masker.json.util.JsonFormatter;
+import dev.blaauwendraad.masker.randomgen.RandomJsonGenerator;
+import dev.blaauwendraad.masker.randomgen.RandomJsonGeneratorConfig;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
-import dev.blaauwendraad.masker.randomgen.RandomJsonGenerator;
-import dev.blaauwendraad.masker.randomgen.RandomJsonGeneratorConfig;
-
+import javax.annotation.Nonnull;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Set;
@@ -24,11 +20,9 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
-import java.util.function.Function;
 import java.util.stream.Stream;
 
-import javax.annotation.CheckForNull;
-import javax.annotation.Nonnull;
+import static org.assertj.core.api.Assertions.fail;
 
 /**
  * This class contains fuzzing tests which are meant to spot infinite loops and program failures for
@@ -45,29 +39,10 @@ final class NoFailingExecutionFuzzingTest {
     @MethodSource("failureFuzzingConfigurations")
     // duration in seconds the tests runs for
     void regularRandomJson(JsonMaskingConfig jsonMaskingConfig) {
-        executeTest(jsonMaskingConfig, null);
-    }
-
-    /**
-     * This test is a fuzzing test that randomly injects some number of {@link
-     * AsciiJsonUtil#isWhiteSpace(byte)} characters in randomly generated JSON in such a way that
-     * the result will also be valid JSON and then the whitespace injected JSON is masked.
-     */
-    @ParameterizedTest
-    @MethodSource("failureFuzzingConfigurations")
-    void whitespaceInjectedRandomJson(JsonMaskingConfig jsonMaskingConfig) {
-        executeTest(
-                jsonMaskingConfig,
-                (jsonNode) -> JsonFormatter.RANDOM_WHITESPACE.format(jsonNode));
-    }
-
-    private void executeTest(JsonMaskingConfig jsonMaskingConfig, @CheckForNull Function<JsonNode, String> jsonMutator) {
         long timeLimit = FuzzingDurationUtil.determineTestTimeLimit(failureFuzzingConfigurations().count());
-        String jsonMutatorUsageMessage =
-                jsonMutator != null ? "WITH a JSON mutator function" : "WITHOUT a JSON mutator function";
         System.out.printf(
-                "Running tests with the following JSON masking configuration: \n%s and %s",
-                jsonMaskingConfig, jsonMutatorUsageMessage);
+                "Running tests with the following JSON masking configuration: \n%s",
+                jsonMaskingConfig);
         Instant startTime = Instant.now();
         AtomicInteger randomTestsExecuted = new AtomicInteger();
         AtomicReference<String> lastExecutedJson = new AtomicReference<>();
@@ -80,19 +55,16 @@ final class NoFailingExecutionFuzzingTest {
                                 RandomJsonGenerator randomJsonGenerator =
                                         new RandomJsonGenerator(RandomJsonGeneratorConfig.builder().createConfig());
                                 JsonNode jsonNode = randomJsonGenerator.createRandomJsonNode();
-                                String mutatedJsonNodeString;
-                                if (jsonMutator != null) {
-                                    mutatedJsonNodeString = jsonMutator.apply(jsonNode);
-                                } else {
-                                    mutatedJsonNodeString = jsonNode.toString();
+                                for (JsonFormatter formatter : JsonFormatter.values()) {
+                                    String mutatedJsonNodeString = formatter.format(jsonNode);
+                                    lastExecutedJson.set(mutatedJsonNodeString);
+                                    Assertions.assertDoesNotThrow(
+                                            () -> keyContainsMasker.mask(mutatedJsonNodeString),
+                                            String.format(
+                                                    "Failed for the following JSON:\n%s",
+                                                    mutatedJsonNodeString));
+                                    randomTestsExecuted.incrementAndGet();
                                 }
-                                lastExecutedJson.set(mutatedJsonNodeString);
-                                Assertions.assertDoesNotThrow(
-                                        () -> keyContainsMasker.mask(mutatedJsonNodeString),
-                                        String.format(
-                                                "Failed for the following JSON:\n%s",
-                                                mutatedJsonNodeString));
-                                randomTestsExecuted.incrementAndGet();
                             }
                         },
                         executor);


### PR DESCRIPTION
As a follow up to #79 let's remove old logic of trying to parse JSON with jackson and also use formatter logic in no failing test.
Additionally it uses the same generated json in all 3 formats instead of generating one per format