### PR TITLE
Fix wildcard usage in jsonpath usage examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ var jsonMasker = JsonMasker.getMasker(
 // allow-mode, JSONPath
 var jsonMasker = JsonMasker.getMasker(
         JsonMaskingConfig.builder()
-                .maskJsonPaths(Set.of("$.id", "$.public.*", "$.nested.name"))
+                .maskJsonPaths(Set.of("$.id", "$.clients.*.phone", "$.nested.name"))
                 .build()
 );
 ```


### PR DESCRIPTION
Leading wildcards (as in `$.public.*`) are not allowed.