### PR TITLE
Refactor all value masking through a unified interface

### DIFF
--- a/src/main/java/dev/blaauwendraad/masker/json/KeyContainsMasker.java
+++ b/src/main/java/dev/blaauwendraad/masker/json/KeyContainsMasker.java
@@ -4,7 +4,6 @@ import dev.blaauwendraad.masker.json.config.JsonMaskingConfig;
 import dev.blaauwendraad.masker.json.config.KeyMaskingConfig;
 import dev.blaauwendraad.masker.json.util.AsciiCharacter;
 import dev.blaauwendraad.masker.json.util.AsciiJsonUtil;
-import dev.blaauwendraad.masker.json.util.Utf8Util;
 
 import javax.annotation.CheckForNull;
 import java.util.Collections;
@@ -73,7 +72,7 @@ public final class KeyContainsMasker implements JsonMasker {
             case '[' -> visitArray(maskingState, keyMaskingConfig);
             case '{' -> visitObject(maskingState, keyMaskingConfig);
             case '-', '0', '1', '2', '3', '4', '5', '6', '7', '8', '9' -> {
-                if (keyMaskingConfig != null && !keyMaskingConfig.isDisableNumberMasking()) {
+                if (keyMaskingConfig != null) {
                     maskNumber(maskingState, keyMaskingConfig);
                 } else {
                     stepOverNumericValue(maskingState);
@@ -87,20 +86,20 @@ public final class KeyContainsMasker implements JsonMasker {
                 }
             }
             case 't' -> {
-                if (keyMaskingConfig != null && !keyMaskingConfig.isDisableBooleanMasking()) {
+                if (keyMaskingConfig != null) {
                     maskBoolean(maskingState, keyMaskingConfig);
                 } else {
-                    maskingState.setCurrentIndex(maskingState.currentIndex() + 4);
+                    maskingState.incrementCurrentIndex(4);
                 }
             }
             case 'f' -> {
-                if (keyMaskingConfig != null && !keyMaskingConfig.isDisableBooleanMasking()) {
+                if (keyMaskingConfig != null) {
                     maskBoolean(maskingState, keyMaskingConfig);
                 } else {
-                    maskingState.setCurrentIndex(maskingState.currentIndex() + 5);
+                    maskingState.incrementCurrentIndex(5);
                 }
             }
-            case 'n' -> maskingState.setCurrentIndex(maskingState.currentIndex() + 4);
+            case 'n' -> maskingState.incrementCurrentIndex(4);
         }
     }
 
@@ -201,42 +200,12 @@ public final class KeyContainsMasker implements JsonMasker {
      * @param keyMaskingConfig the {@link KeyMaskingConfig} for the corresponding JSON key
      */
     private void maskString(MaskingState maskingState, KeyMaskingConfig keyMaskingConfig) {
-        int valueStartIndex = maskingState.currentIndex();
-        stepOverStringValue(maskingState); // we step over the string to find its length to mask it
-        int targetValueLength = maskingState.currentIndex() - valueStartIndex;
-        if (keyMaskingConfig.getMaskStringsWith() != null) {
-            maskingState.replaceTargetValueWith(
-                    valueStartIndex,
-                    targetValueLength,
-                    keyMaskingConfig.getMaskStringsWith(),
-                    1
-            );
-        } else if (keyMaskingConfig.getMaskStringCharactersWith() != null) {
-            /*
-            So we don't add asterisks for escape characters or additional encoding bytes (which are not part of the String length)
+        maskingState.setCurrentValueStartIndex();
+        stepOverStringValue(maskingState);
 
-            The actual length of the string is the length minus escape characters (which are not part of the
-            string length). Also, unicode characters are denoted as 4-hex digits but represent actually
-            just one character, so for each of them 3 asterisks should be removed.
-             */
-            valueStartIndex += 1; // offset by opening quote
-            targetValueLength -= 2; // remove quotes from the value length
+        keyMaskingConfig.getStringValueMasker().maskValue(maskingState);
 
-            int nonVisibleCharacters = Utf8Util.countNonVisibleCharacters(
-                    maskingState.getMessage(),
-                    valueStartIndex,
-                    targetValueLength
-            );
-
-            maskingState.replaceTargetValueWith(
-                    valueStartIndex,
-                    targetValueLength,
-                    keyMaskingConfig.getMaskStringCharactersWith(),
-                    targetValueLength - nonVisibleCharacters
-            );
-        } else {
-            throw new IllegalStateException("Invalid string masking configuration");
-        }
+        maskingState.unsetCurrentValueStartIndex();
     }
 
     /**
@@ -252,26 +221,12 @@ public final class KeyContainsMasker implements JsonMasker {
      */
     private void maskNumber(MaskingState maskingState, KeyMaskingConfig keyMaskingConfig) {
         // This block deals with numeric values
-        int targetValueStartIndex = maskingState.currentIndex();
+        maskingState.setCurrentValueStartIndex();
         stepOverNumericValue(maskingState);
-        int targetValueLength = maskingState.currentIndex() - targetValueStartIndex;
-        if (keyMaskingConfig.getMaskNumbersWith() != null) {
-            maskingState.replaceTargetValueWith(
-                    targetValueStartIndex,
-                    targetValueLength,
-                    keyMaskingConfig.getMaskNumbersWith(),
-                    1
-            );
-        } else if (keyMaskingConfig.getMaskNumberDigitsWith() != null) {
-            maskingState.replaceTargetValueWith(
-                    targetValueStartIndex,
-                    targetValueLength,
-                    keyMaskingConfig.getMaskNumberDigitsWith(),
-                    targetValueLength
-            );
-        } else {
-            throw new IllegalStateException("Invalid number masking configuration");
-        }
+
+        keyMaskingConfig.getNumberValueMasker().maskValue(maskingState);
+
+        maskingState.unsetCurrentValueStartIndex();
     }
 
     /**
@@ -283,19 +238,12 @@ public final class KeyContainsMasker implements JsonMasker {
      * @param keyMaskingConfig the {@link KeyMaskingConfig} for the corresponding JSON key
      */
     private void maskBoolean(MaskingState maskingState, KeyMaskingConfig keyMaskingConfig) {
-        // true (4 bytes) or false (5 bytes)
-        int targetValueLength = AsciiCharacter.isLowercaseT(maskingState.byteAtCurrentIndex()) ? 4 : 5;
-        if (keyMaskingConfig.getMaskBooleansWith() != null) {
-            maskingState.replaceTargetValueWith(
-                    maskingState.currentIndex(),
-                    targetValueLength,
-                    keyMaskingConfig.getMaskBooleansWith(),
-                    1
-            );
-        } else {
-            throw new IllegalStateException("Invalid boolean masking configuration");
-        }
-        maskingState.setCurrentIndex(maskingState.currentIndex() + targetValueLength);
+        maskingState.setCurrentValueStartIndex();
+        maskingState.incrementCurrentIndex(AsciiCharacter.isLowercaseT(maskingState.byteAtCurrentIndex()) ? 4 : 5);
+
+        keyMaskingConfig.getBooleanValueMasker().maskValue(maskingState);
+
+        maskingState.unsetCurrentValueStartIndex();
     }
 
     /**
@@ -309,9 +257,9 @@ public final class KeyContainsMasker implements JsonMasker {
     private static void stepOverValue(MaskingState maskingState) {
         switch (maskingState.byteAtCurrentIndex()) {
             case '"' -> stepOverStringValue(maskingState);
-            case '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '-' -> stepOverNumericValue(maskingState);
-            case 't', 'n' -> maskingState.setCurrentIndex(maskingState.currentIndex() + 4); // true or null
-            case 'f' -> maskingState.setCurrentIndex(maskingState.currentIndex() + 5); // false
+            case '-', '0', '1', '2', '3', '4', '5', '6', '7', '8', '9' -> stepOverNumericValue(maskingState);
+            case 't', 'n' -> maskingState.incrementCurrentIndex(4); // true or null
+            case 'f' -> maskingState.incrementCurrentIndex(5); // false
             case '{' -> stepOverObject(maskingState);
             case '[' -> stepOverArray(maskingState);
         }

--- a/src/main/java/dev/blaauwendraad/masker/json/ValueMasker.java
+++ b/src/main/java/dev/blaauwendraad/masker/json/ValueMasker.java
@@ -1,0 +1,85 @@
+package dev.blaauwendraad.masker.json;
+
+import java.nio.charset.StandardCharsets;
+import java.util.function.Function;
+
+@FunctionalInterface
+public interface ValueMasker {
+
+    static ValueMasker maskWith(String value) {
+        byte[] replacementBytes = ("\"" + value + "\"").getBytes(StandardCharsets.UTF_8);
+        return context -> context.replaceValue(0, context.valueLength(), replacementBytes, 1);
+    }
+
+    static ValueMasker maskWith(int value) {
+        byte[] replacementBytes = String.valueOf(value).getBytes(StandardCharsets.UTF_8);
+        return context -> context.replaceValue(0, context.valueLength(), replacementBytes, 1);
+    }
+
+    static ValueMasker maskWith(boolean value) {
+        byte[] replacementBytes = String.valueOf(value).getBytes(StandardCharsets.UTF_8);
+        return context -> context.replaceValue(0, context.valueLength(), replacementBytes, 1);
+    }
+
+    static ValueMasker maskStringCharactersWith(String value) {
+        byte[] replacementBytes = value.getBytes(StandardCharsets.UTF_8);
+        return context -> {
+            /*
+            So we don't add asterisks for escape characters or additional encoding bytes (which are not part of the String length)
+
+            The actual length of the string is the length minus escape characters (which are not part of the
+            string length). Also, unicode characters are denoted as 4-hex digits but represent actually
+            just one character, so for each of them 3 asterisks should be removed.
+             */
+            int stringValueStart = 1; // skip the opening quote
+            int stringValueLength = context.valueLength() - 2; // skip both quotes
+            int nonVisibleCharacters = context.countNonVisibleCharacters(stringValueStart, stringValueLength);
+            int maskLength = stringValueLength - nonVisibleCharacters;
+            context.replaceValue(stringValueStart, stringValueLength, replacementBytes, maskLength);
+        };
+    }
+
+    static ValueMasker maskNumberDigitsWith(int digit) {
+        if (digit < 1 || digit > 9) {
+            throw new IllegalArgumentException("Masking digit must be between 1 and 9 to avoid leading zeroes");
+        }
+        byte[] replacementBytes = String.valueOf(digit).getBytes(StandardCharsets.UTF_8);
+        return context -> context.replaceValue(0, context.valueLength(), replacementBytes, context.valueLength());
+    }
+
+    static ValueMasker noop() {
+        return context -> {
+        };
+    }
+
+    static ValueMasker maskEmail(int keepPrefixLength, boolean keepDomain, String mask) {
+        byte[] replacementBytes = mask.getBytes(StandardCharsets.UTF_8);
+        return context -> {
+            int suffixLength = 1; // keep closing quote
+            if (keepDomain) {
+                for (int i = 0; i < context.valueLength(); i++) {
+                    if (context.getByte(i) == '@') {
+                        suffixLength = context.valueLength() - i;
+                    }
+                }
+            }
+            int maskLength = context.valueLength() - keepPrefixLength - suffixLength;
+            context.replaceValue(
+                    keepPrefixLength + 1, // keep opening quote
+                    maskLength - 1, // keep closing quote
+                    replacementBytes,
+                    1
+            );
+        };
+    }
+
+    static ValueMasker maskStringWithFunction(Function<String, String> masker) {
+        return context -> {
+            String value = context.asString();
+            String maskedValue = masker.apply(value);
+            context.replaceValue(0, context.valueLength(), maskedValue.getBytes(StandardCharsets.UTF_8), 1);
+        };
+    }
+
+    void maskValue(ValueMaskerContext context);
+}

--- a/src/main/java/dev/blaauwendraad/masker/json/ValueMaskerContext.java
+++ b/src/main/java/dev/blaauwendraad/masker/json/ValueMaskerContext.java
@@ -1,0 +1,13 @@
+package dev.blaauwendraad.masker.json;
+
+public interface ValueMaskerContext {
+    byte getByte(int index);
+
+    int valueLength();
+
+    void replaceValue(int fromIndex, int length, byte[] mask, int maskRepeat);
+
+    int countNonVisibleCharacters(int fromIndex, int length);
+
+    String asString();
+}

--- a/src/main/java/dev/blaauwendraad/masker/json/config/KeyMaskingConfig.java
+++ b/src/main/java/dev/blaauwendraad/masker/json/config/KeyMaskingConfig.java
@@ -1,57 +1,29 @@
 package dev.blaauwendraad.masker.json.config;
 
+import dev.blaauwendraad.masker.json.ValueMasker;
+
 import javax.annotation.CheckForNull;
 import java.nio.charset.StandardCharsets;
 import java.util.Objects;
 
 public final class KeyMaskingConfig {
-    @CheckForNull
-    private final byte[] maskStringsWith;
-    @CheckForNull
-    private final byte[] maskStringCharactersWith;
-    @CheckForNull
-    private final byte[] maskNumbersWith;
-    @CheckForNull
-    private final byte[] maskNumberDigitsWith;
-    @CheckForNull
-    private final byte[] maskBooleansWith;
+    private final ValueMasker maskStringsWith;
+    private final ValueMasker maskNumbersWith;
+    private final ValueMasker maskBooleansWith;
 
     KeyMaskingConfig(KeyMaskingConfig.Builder builder) {
-        if (builder.maskStringsWith != null) {
-            this.maskStringsWith = ("\"" + builder.maskStringsWith + "\"").getBytes(StandardCharsets.UTF_8);
-            this.maskStringCharactersWith = null;
-        } else if (builder.maskStringCharactersWith != null) {
-            this.maskStringsWith = null;
-            this.maskStringCharactersWith = builder.maskStringCharactersWith.getBytes(StandardCharsets.UTF_8);
-        } else {
-            this.maskStringsWith = "\"***\"".getBytes(StandardCharsets.UTF_8);
-            this.maskStringCharactersWith = null;
-        }
-        if (builder.maskNumbersWithString != null) {
-            this.maskNumbersWith = ("\"" + builder.maskNumbersWithString + "\"").getBytes(StandardCharsets.UTF_8);
-            this.maskNumberDigitsWith = null;
-        } else if (builder.maskNumbersWith != null) {
-            this.maskNumbersWith = builder.maskNumbersWith.toString().getBytes(StandardCharsets.UTF_8);
-            this.maskNumberDigitsWith = null;
-        } else if (builder.maskNumberDigitsWith != null) {
-            this.maskNumbersWith = null;
-            this.maskNumberDigitsWith = builder.maskNumberDigitsWith.toString().getBytes(StandardCharsets.UTF_8);
-        } else if (builder.disableNumberMasking != null && builder.disableNumberMasking) {
-            this.maskNumbersWith = null;
-            this.maskNumberDigitsWith = null;
-        } else {
-            this.maskNumbersWith = "\"###\"".getBytes(StandardCharsets.UTF_8);
-            this.maskNumberDigitsWith = null;
-        }
-        if (builder.maskBooleansWithString != null) {
-            this.maskBooleansWith = ("\"" + builder.maskBooleansWithString + "\"").getBytes(StandardCharsets.UTF_8);
-        } else if (builder.maskBooleansWith != null) {
-            this.maskBooleansWith = builder.maskBooleansWith.toString().getBytes(StandardCharsets.UTF_8);
-        } else if (builder.disableBooleanMasking != null && builder.disableBooleanMasking) {
-            this.maskBooleansWith = null;
-        } else {
-            this.maskBooleansWith = "\"&&&\"".getBytes(StandardCharsets.UTF_8);
-        }
+        this.maskStringsWith = Objects.requireNonNullElseGet(
+                builder.maskStringsWith,
+                () -> ValueMasker.maskWith("***")
+        );
+        this.maskNumbersWith = Objects.requireNonNullElseGet(
+                builder.maskNumbersWith,
+                () -> ValueMasker.maskWith("###")
+        );
+        this.maskBooleansWith = Objects.requireNonNullElseGet(
+                builder.maskBooleansWith,
+                () -> ValueMasker.maskWith("&&&")
+        );
     }
 
     /**
@@ -64,90 +36,45 @@ public final class KeyMaskingConfig {
     }
 
     /**
-     * @see Builder#maskStringsWith(String)
+     * Returns a function to mask a string value.
      */
-    @CheckForNull
-    public byte[] getMaskStringsWith() {
+    public ValueMasker getStringValueMasker() {
         return maskStringsWith;
     }
 
     /**
-     * @see Builder#maskStringCharactersWith(String)
+     * Returns a function to mask a number value.
      */
-    @CheckForNull
-    public byte[] getMaskStringCharactersWith() {
-        return maskStringCharactersWith;
-    }
-
-    /**
-     * @see Builder#disableNumberMasking()
-     */
-    public boolean isDisableNumberMasking() {
-        return maskNumbersWith == null && maskNumberDigitsWith == null;
-    }
-
-    /**
-     * @see Builder#maskNumbersWith(int)
-     */
-    @CheckForNull
-    public byte[] getMaskNumbersWith() {
+    public ValueMasker getNumberValueMasker() {
         return maskNumbersWith;
     }
 
     /**
-     * @see Builder#maskNumberDigitsWith(int)
+     * Returns a function to mask a number value.
      */
-    @CheckForNull
-    public byte[] getMaskNumberDigitsWith() {
-        return maskNumberDigitsWith;
-    }
-
-    /**
-     * @see Builder#disableBooleanMasking()
-     */
-    public boolean isDisableBooleanMasking() {
-        return maskBooleansWith == null;
-    }
-
-    /**
-     * @see Builder#maskBooleansWith(boolean)
-     */
-    @CheckForNull
-    public byte[] getMaskBooleansWith() {
+    public ValueMasker getBooleanValueMasker() {
         return maskBooleansWith;
     }
-
-    @Override
-    public String toString() {
-        return "KeyMaskingConfig{" +
-                "maskStringsWith='" + bytesToString(maskStringsWith) + '\'' +
-                ", maskStringCharactersWith='" + bytesToString(maskStringCharactersWith) + '\'' +
-                ", maskNumbersWith=" + bytesToString(maskNumbersWith) +
-                ", maskNumberDigitsWith=" + bytesToString(maskNumberDigitsWith) +
-                ", maskBooleansWith=" + bytesToString(maskBooleansWith) +
-                '}';
-    }
+// TODO: it would be nice to have it back for debuggability purposes
+//    @Override
+//    public String toString() {
+//        return "KeyMaskingConfig{" +
+//                "maskStringsWith='" + bytesToString(maskStringsWith) + '\'' +
+//                ", maskStringCharactersWith='" + bytesToString(maskStringCharactersWith) + '\'' +
+//                ", maskNumbersWith=" + bytesToString(maskNumbersWith) +
+//                ", maskNumberDigitsWith=" + bytesToString(maskNumberDigitsWith) +
+//                ", maskBooleansWith=" + bytesToString(maskBooleansWith) +
+//                '}';
+//    }
 
     private String bytesToString(@CheckForNull byte[] bytes) {
         return bytes != null ? new String(bytes, StandardCharsets.UTF_8) : null;
     }
 
     public static class Builder {
-
-        // String masking, mutually exclusive options
-        private String maskStringsWith;
-        private String maskStringCharactersWith;
-
-        // Number masking, mutually exclusive options
-        private Boolean disableNumberMasking;
-        private String maskNumbersWithString;
-        private Integer maskNumbersWith;
-        private Integer maskNumberDigitsWith;
-
-        // Boolean masking, mutually exclusive options
-        private Boolean disableBooleanMasking;
-        private String maskBooleansWithString;
-        private Boolean maskBooleansWith;
+        private ValueMasker maskStringsWith;
+        private ValueMasker maskNumbersWith;
+        private ValueMasker maskBooleansWith;
 
         private Builder() {
         }
@@ -163,11 +90,8 @@ public final class KeyMaskingConfig {
          * @return the builder instance
          */
         public Builder maskStringsWith(String value) {
-            if (maskStringsWith != null) {
-                throw new IllegalArgumentException("'maskStringsWith(String)' was already set");
-            }
             checkMutuallyExclusiveStringMaskingOptions();
-            maskStringsWith = value;
+            maskStringsWith = ValueMasker.maskWith(value);
             return this;
         }
 
@@ -180,11 +104,14 @@ public final class KeyMaskingConfig {
          * @return the builder instance
          */
         public Builder maskStringCharactersWith(String value) {
-            if (maskStringCharactersWith != null) {
-                throw new IllegalArgumentException("'maskStringCharactersWith(String)' was already set");
-            }
             checkMutuallyExclusiveStringMaskingOptions();
-            maskStringCharactersWith = value;
+            maskStringsWith = ValueMasker.maskStringCharactersWith(value);
+            return this;
+        }
+
+        public Builder maskStringsWith(ValueMasker valueMasker) {
+            checkMutuallyExclusiveStringMaskingOptions();
+            maskStringsWith = valueMasker;
             return this;
         }
 
@@ -198,11 +125,8 @@ public final class KeyMaskingConfig {
          * @return the builder instance
          */
         public Builder disableNumberMasking() {
-            if (disableNumberMasking != null) {
-                throw new IllegalArgumentException("'disableNumberMasking()' was already set");
-            }
             checkMutuallyExclusiveNumberMaskingOptions();
-            disableNumberMasking = true;
+            maskNumbersWith = ValueMasker.noop();
             return this;
         }
 
@@ -219,11 +143,8 @@ public final class KeyMaskingConfig {
          * @return the builder instance
          */
         public Builder maskNumbersWith(String value) {
-            if (maskNumbersWithString != null) {
-                throw new IllegalArgumentException("'maskNumbersWith(String)' was already set");
-            }
             checkMutuallyExclusiveNumberMaskingOptions();
-            maskNumbersWithString = Objects.requireNonNull(value);
+            maskNumbersWith = ValueMasker.maskWith(value);
             return this;
         }
 
@@ -242,7 +163,7 @@ public final class KeyMaskingConfig {
                 throw new IllegalArgumentException("'maskNumbersWith(int)' was already set");
             }
             checkMutuallyExclusiveNumberMaskingOptions();
-            maskNumbersWith = value;
+            maskNumbersWith = ValueMasker.maskWith(value);
             return this;
         }
 
@@ -257,14 +178,14 @@ public final class KeyMaskingConfig {
          * @return the builder instance
          */
         public Builder maskNumberDigitsWith(int digit) {
-            if (maskNumberDigitsWith != null) {
-                throw new IllegalArgumentException("'maskNumberDigitsWith(int)' was already set");
-            }
             checkMutuallyExclusiveNumberMaskingOptions();
-            if (digit < 1 || digit > 9) {
-                throw new IllegalArgumentException("Masking digit must be between 1 and 9 to avoid leading zeroes");
-            }
-            maskNumberDigitsWith = digit;
+            maskNumbersWith = ValueMasker.maskNumberDigitsWith(digit);
+            return this;
+        }
+
+        public Builder maskNumbersWith(ValueMasker valueMasker) {
+            checkMutuallyExclusiveNumberMaskingOptions();
+            maskNumbersWith = valueMasker;
             return this;
         }
 
@@ -277,11 +198,8 @@ public final class KeyMaskingConfig {
          * @return the builder instance
          */
         public Builder disableBooleanMasking() {
-            if (disableBooleanMasking != null) {
-                throw new IllegalArgumentException("'disableBooleanMasking()' was already set");
-            }
             checkMutuallyExclusiveBooleanMaskingOptions();
-            disableBooleanMasking = true;
+            maskBooleansWith = ValueMasker.noop();
             return this;
         }
 
@@ -297,11 +215,8 @@ public final class KeyMaskingConfig {
          * @return the builder instance
          */
         public Builder maskBooleansWith(String value) {
-            if (maskBooleansWithString != null) {
-                throw new IllegalArgumentException("'maskBooleansWith(String)' was already set");
-            }
             checkMutuallyExclusiveBooleanMaskingOptions();
-            maskBooleansWithString = Objects.requireNonNull(value);
+            maskBooleansWith = ValueMasker.maskWith(value);
             return this;
         }
 
@@ -315,11 +230,14 @@ public final class KeyMaskingConfig {
          * @return the builder instance
          */
         public Builder maskBooleansWith(boolean value) {
-            if (maskBooleansWith != null) {
-                throw new IllegalArgumentException("'maskBooleansWith(boolean)' was already set");
-            }
             checkMutuallyExclusiveBooleanMaskingOptions();
-            maskBooleansWith = value;
+            maskBooleansWith = ValueMasker.maskWith(value);
+            return this;
+        }
+
+        public Builder maskBooleansWith(ValueMasker valueMasker) {
+            checkMutuallyExclusiveBooleanMaskingOptions();
+            maskBooleansWith = valueMasker;
             return this;
         }
 
@@ -333,19 +251,19 @@ public final class KeyMaskingConfig {
         }
 
         private void checkMutuallyExclusiveStringMaskingOptions() {
-            if (maskStringsWith != null || maskStringCharactersWith != null) {
-                throw new IllegalArgumentException("'maskStringsWith(String)' and 'maskStringCharactersWith(String)' are mutually exclusive");
+            if (maskStringsWith != null) {
+                throw new IllegalArgumentException("'maskStringsWith(String)' and 'maskStringCharactersWith(String)' are mutually exclusive and cannot be set twice");
             }
         }
 
         private void checkMutuallyExclusiveNumberMaskingOptions() {
-            if (disableNumberMasking != null || maskNumbersWith != null || maskNumbersWithString != null || maskNumberDigitsWith != null) {
+            if (maskNumbersWith != null) {
                 throw new IllegalArgumentException("'disableNumberMasking()', 'maskNumbersWith(int)', 'maskNumbersWith(String)' and 'maskNumberDigitsWith(int)' are mutually exclusive");
             }
         }
 
         private void checkMutuallyExclusiveBooleanMaskingOptions() {
-            if (disableBooleanMasking != null || maskBooleansWith != null || maskBooleansWithString != null) {
+            if (maskBooleansWith != null) {
                 throw new IllegalArgumentException("'disableBooleanMasking()', 'maskBooleansWith(boolean)' and 'maskBooleansWith(String)' are mutually exclusive");
             }
         }

--- a/src/test/java/dev/blaauwendraad/masker/json/KeyMatcherTest.java
+++ b/src/test/java/dev/blaauwendraad/masker/json/KeyMatcherTest.java
@@ -2,6 +2,7 @@ package dev.blaauwendraad.masker.json;
 
 import dev.blaauwendraad.masker.json.config.JsonMaskingConfig;
 import dev.blaauwendraad.masker.json.config.KeyMaskingConfig;
+import dev.blaauwendraad.masker.json.util.ByteValueMaskerContext;
 import org.assertj.core.api.Assertions;
 import org.assertj.core.api.ObjectAssert;
 import org.junit.jupiter.api.Test;
@@ -70,14 +71,22 @@ final class KeyMatcherTest {
 
         assertThatConfig(keyMatcher, "maskMe")
                 .isNotNull()
-                .extracting(KeyMaskingConfig::getMaskStringsWith)
-                .extracting(bytes -> new String(bytes, StandardCharsets.UTF_8))
+                .extracting(KeyMaskingConfig::getStringValueMasker)
+                .extracting(masker -> {
+                    ByteValueMaskerContext context = new ByteValueMaskerContext("value");
+                    masker.maskValue(context);
+                    return context.asString();
+                })
                 .isEqualTo("\"***\"");
 
         assertThatConfig(keyMatcher, "maskMeLikeCIA")
                 .isNotNull()
-                .extracting(KeyMaskingConfig::getMaskStringsWith)
-                .extracting(bytes -> new String(bytes, StandardCharsets.UTF_8))
+                .extracting(KeyMaskingConfig::getStringValueMasker)
+                .extracting(masker -> {
+                    ByteValueMaskerContext context = new ByteValueMaskerContext("value");
+                    masker.maskValue(context);
+                    return context.asString();
+                })
                 .isEqualTo("\"[redacted]\"");
     }
 
@@ -93,14 +102,22 @@ final class KeyMatcherTest {
 
         assertThatConfig(keyMatcher, "maskMe")
                 .isNotNull()
-                .extracting(KeyMaskingConfig::getMaskStringsWith)
-                .extracting(bytes -> new String(bytes, StandardCharsets.UTF_8))
+                .extracting(KeyMaskingConfig::getStringValueMasker)
+                .extracting(masker -> {
+                    ByteValueMaskerContext context = new ByteValueMaskerContext("value");
+                    masker.maskValue(context);
+                    return context.asString();
+                })
                 .isEqualTo("\"***\"");
 
         assertThatConfig(keyMatcher, "maskMeLikeCIA")
                 .isNotNull()
-                .extracting(KeyMaskingConfig::getMaskStringsWith)
-                .extracting(bytes -> new String(bytes, StandardCharsets.UTF_8))
+                .extracting(KeyMaskingConfig::getStringValueMasker)
+                .extracting(masker -> {
+                    ByteValueMaskerContext context = new ByteValueMaskerContext("value");
+                    masker.maskValue(context);
+                    return context.asString();
+                })
                 .isEqualTo("\"[redacted]\"");
     }
 

--- a/src/test/java/dev/blaauwendraad/masker/json/ParseAndMaskUtil.java
+++ b/src/test/java/dev/blaauwendraad/masker/json/ParseAndMaskUtil.java
@@ -4,21 +4,17 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.fasterxml.jackson.databind.node.BigIntegerNode;
 import com.fasterxml.jackson.databind.node.BooleanNode;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.NumericNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.databind.node.TextNode;
-import com.fasterxml.jackson.databind.node.ValueNode;
 import dev.blaauwendraad.masker.json.config.JsonMaskingConfig;
 import dev.blaauwendraad.masker.json.config.KeyMaskingConfig;
 import dev.blaauwendraad.masker.json.path.JsonPath;
-import dev.blaauwendraad.masker.json.path.JsonPathParser;
+import dev.blaauwendraad.masker.json.util.ByteValueMaskerContext;
 
 import javax.annotation.Nonnull;
-import java.math.BigInteger;
-import java.nio.charset.StandardCharsets;
 import java.util.Iterator;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -37,7 +33,7 @@ public final class ParseAndMaskUtil {
     }
 
     @Nonnull
-    static JsonNode mask(JsonNode jsonNode, JsonMaskingConfig jsonMaskingConfig) {
+    static JsonNode mask(JsonNode jsonNode, JsonMaskingConfig jsonMaskingConfig) throws JsonProcessingException {
         if (jsonMaskingConfig.isInAllowMode() && !jsonNode.isArray() && !jsonNode.isObject()) {
             return maskJsonValue(jsonNode, jsonMaskingConfig.getDefaultConfig(), jsonMaskingConfig, jsonMaskingConfig.getTargetKeys());
         }
@@ -50,7 +46,6 @@ public final class ParseAndMaskUtil {
                     .map(JsonPath::toString)
                     .collect(Collectors.toSet());
         } else {
-            JsonPathParser jsonPathParser = new JsonPathParser();
             casingAppliedTargetKeys = jsonMaskingConfig.getTargetKeys()
                     .stream()
                     .map(String::toLowerCase)
@@ -75,33 +70,32 @@ public final class ParseAndMaskUtil {
             String currentJsonPath,
             Set<String> casingAppliedTargetKeys,
             Set<String> casingAppliedTargetJsonPathKeys
-    ) {
+    ) throws JsonProcessingException {
         if (jsonNode instanceof ObjectNode objectNode) {
-            objectNode.fieldNames().forEachRemaining(
-                    key -> {
-                        String jsonPathKey = currentJsonPath + "." + key;
-                        String casingAppliedJsonPathKey = jsonMaskingConfig.caseSensitiveTargetKeys()
-                                ? jsonPathKey
-                                : jsonPathKey.toLowerCase();
-                        if (jsonMaskingConfig.isInMaskMode()
-                                && isTargetKey(casingAppliedJsonPathKey, casingAppliedTargetKeys, casingAppliedTargetJsonPathKeys)
-                                || jsonMaskingConfig.isInAllowMode()
-                                && !isTargetKey(casingAppliedJsonPathKey, casingAppliedTargetKeys, casingAppliedTargetJsonPathKeys)) {
-                            objectNode.replace(
-                                    key,
-                                    maskJsonValue(
-                                            objectNode.get(key),
-                                            jsonMaskingConfig.getConfig(key),
-                                            jsonMaskingConfig,
-                                            casingAppliedTargetKeys
-                                    )
-                            );
-                        } else if (!jsonMaskingConfig.isInAllowMode()
-                                || !isTargetKey(casingAppliedJsonPathKey, casingAppliedTargetKeys, casingAppliedTargetJsonPathKeys)) {
-                            mask(jsonNode.get(key), jsonMaskingConfig, jsonPathKey, casingAppliedTargetKeys, casingAppliedTargetJsonPathKeys);
-                        }
-                    }
-            );
+            Iterable<String> fieldNames = objectNode::fieldNames;
+            for (String fieldName : fieldNames) {
+                String jsonPathKey = currentJsonPath + "." + fieldName;
+                String casingAppliedJsonPathKey = jsonMaskingConfig.caseSensitiveTargetKeys()
+                        ? jsonPathKey
+                        : jsonPathKey.toLowerCase();
+                if (jsonMaskingConfig.isInMaskMode()
+                    && isTargetKey(casingAppliedJsonPathKey, casingAppliedTargetKeys, casingAppliedTargetJsonPathKeys)
+                    || jsonMaskingConfig.isInAllowMode()
+                       && !isTargetKey(casingAppliedJsonPathKey, casingAppliedTargetKeys, casingAppliedTargetJsonPathKeys)) {
+                    objectNode.replace(
+                            fieldName,
+                            maskJsonValue(
+                                    objectNode.get(fieldName),
+                                    jsonMaskingConfig.getConfig(fieldName),
+                                    jsonMaskingConfig,
+                                    casingAppliedTargetKeys
+                            )
+                    );
+                } else if (!jsonMaskingConfig.isInAllowMode()
+                           || !isTargetKey(casingAppliedJsonPathKey, casingAppliedTargetKeys, casingAppliedTargetJsonPathKeys)) {
+                    mask(jsonNode.get(fieldName), jsonMaskingConfig, jsonPathKey, casingAppliedTargetKeys, casingAppliedTargetJsonPathKeys);
+                }
+            }
         } else if (jsonNode instanceof ArrayNode arrayNode) {
             String jsonPathKey = currentJsonPath + "[*]";
             String casingAppliedJsonPathKey = jsonMaskingConfig.caseSensitiveTargetKeys()
@@ -143,7 +137,7 @@ public final class ParseAndMaskUtil {
             KeyMaskingConfig config,
             JsonMaskingConfig jsonMaskingConfig,
             Set<String> casingAppliedTargetKeys
-    ) {
+    ) throws JsonProcessingException {
         return switch (jsonNode.getNodeType()) {
             case STRING -> maskTextNode((TextNode) jsonNode, config);
             case NUMBER -> maskNumericNode((NumericNode) jsonNode, config);
@@ -154,59 +148,24 @@ public final class ParseAndMaskUtil {
         };
     }
 
-    private static JsonNode maskBooleanNode(BooleanNode booleanNode, KeyMaskingConfig config) {
-        if (config.isDisableBooleanMasking()) {
-            return booleanNode;
-        }
-        if (config.getMaskBooleansWith() == null) {
-            throw new IllegalArgumentException("Invalid masking configuration for key: " + config);
-        }
-        String maskBooleansWith = new String(config.getMaskBooleansWith(), StandardCharsets.UTF_8);
-        if (maskBooleansWith.startsWith("\"")) {
-            return new TextNode(maskBooleansWith.substring(1, maskBooleansWith.length() - 1));
-        } else {
-            return BooleanNode.valueOf(Boolean.parseBoolean(maskBooleansWith));
-        }
+    private static JsonNode maskBooleanNode(BooleanNode booleanNode, KeyMaskingConfig config) throws JsonProcessingException {
+        ByteValueMaskerContext context = new ByteValueMaskerContext(booleanNode.toString());
+        config.getBooleanValueMasker().maskValue(context);
+        return DEFAULT_OBJECT_MAPPER.readTree(context.asString());
     }
 
     @Nonnull
-    private static TextNode maskTextNode(TextNode textNode, KeyMaskingConfig config) {
-        String text = textNode.textValue();
-        if (config.getMaskStringsWith() != null) {
-            // strip the quotes
-            text = new String(config.getMaskStringsWith(), 1, config.getMaskStringsWith().length - 2, StandardCharsets.UTF_8);
-        } else if (config.getMaskStringCharactersWith() != null) {
-            text = new String(config.getMaskStringCharactersWith(), StandardCharsets.UTF_8).repeat(text.length());
-        } else {
-            throw new IllegalArgumentException("Invalid masking configuration for key: " + config);
-        }
-        return new TextNode(text);
+    private static JsonNode maskTextNode(TextNode textNode, KeyMaskingConfig config) throws JsonProcessingException {
+        ByteValueMaskerContext context = new ByteValueMaskerContext(textNode.toString());
+        config.getStringValueMasker().maskValue(context);
+        return DEFAULT_OBJECT_MAPPER.readTree(context.asString());
     }
 
     @Nonnull
-    private static ValueNode maskNumericNode(NumericNode numericNode, KeyMaskingConfig config) {
-        if (config.isDisableNumberMasking()) {
-            return numericNode;
-        }
-        String text = numericNode.asText();
-        if (config.getMaskNumbersWith() != null) {
-            String maskNumbersWith = new String(config.getMaskNumbersWith(), StandardCharsets.UTF_8);
-            if (maskNumbersWith.startsWith("\"")) {
-                return new TextNode(maskNumbersWith.substring(1, maskNumbersWith.length() - 1));
-            } else {
-                return new BigIntegerNode(BigInteger.valueOf(Long.parseLong(maskNumbersWith)));
-            }
-        } else if (config.getMaskNumberDigitsWith() != null) {
-            int maskNumberDigitsWith = Integer.parseInt(new String(config.getMaskNumberDigitsWith(), StandardCharsets.UTF_8));
-            BigInteger mask = BigInteger.valueOf(maskNumberDigitsWith);
-            for (int i = 1; i < text.length(); i++) {
-                mask = mask.multiply(BigInteger.TEN);
-                mask = mask.add(BigInteger.valueOf(maskNumberDigitsWith));
-            }
-            return new BigIntegerNode(mask);
-        } else {
-            throw new IllegalArgumentException("Invalid masking configuration for key: " + config);
-        }
+    private static JsonNode maskNumericNode(NumericNode numericNode, KeyMaskingConfig config) throws JsonProcessingException {
+        ByteValueMaskerContext context = new ByteValueMaskerContext(numericNode.toString());
+        config.getNumberValueMasker().maskValue(context);
+        return DEFAULT_OBJECT_MAPPER.readTree(context.asString());
     }
 
     @Nonnull
@@ -215,7 +174,7 @@ public final class ParseAndMaskUtil {
             KeyMaskingConfig config,
             JsonMaskingConfig jsonMaskingConfig,
             Set<String> casingAppliedTargetKeys
-    ) {
+    ) throws JsonProcessingException {
         ArrayNode maskedArrayNode = JsonNodeFactory.instance.arrayNode();
         for (JsonNode element : arrayNode) {
             maskedArrayNode.add(maskJsonValue(element, config, jsonMaskingConfig, casingAppliedTargetKeys));
@@ -229,7 +188,7 @@ public final class ParseAndMaskUtil {
             KeyMaskingConfig config,
             JsonMaskingConfig jsonMaskingConfig,
             Set<String> casingAppliedTargetKeys
-    ) {
+    ) throws JsonProcessingException {
         ObjectNode maskedObjectNode = JsonNodeFactory.instance.objectNode();
         Iterator<String> fieldNames = objectNode.fieldNames();
 

--- a/src/test/java/dev/blaauwendraad/masker/json/util/ByteValueMaskerContext.java
+++ b/src/test/java/dev/blaauwendraad/masker/json/util/ByteValueMaskerContext.java
@@ -1,0 +1,71 @@
+package dev.blaauwendraad.masker.json.util;
+
+import dev.blaauwendraad.masker.json.ValueMaskerContext;
+
+import java.nio.charset.StandardCharsets;
+
+public class ByteValueMaskerContext implements ValueMaskerContext {
+    private byte[] value;
+
+    public ByteValueMaskerContext(byte[] value) {
+        this.value = value;
+    }
+
+    public ByteValueMaskerContext(String value) {
+        this(value.getBytes(StandardCharsets.UTF_8));
+    }
+
+    @Override
+    public byte getByte(int index) {
+        return value[index];
+    }
+
+    @Override
+    public int valueLength() {
+        return value.length;
+    }
+
+    @Override
+    public void replaceValue(int fromIndex, int length, byte[] mask, int maskRepeat) {
+        int suffixLength = value.length - (length + fromIndex);
+        int newArraySize = fromIndex + (mask.length * maskRepeat) + suffixLength;
+        byte[] maskedValue = new byte[newArraySize];
+        // copy the prefix
+        System.arraycopy(
+                value,
+                0,
+                maskedValue,
+                0,
+                fromIndex
+        );
+        // copy the mask(s)
+        for (int i = 0; i < maskRepeat; i++) {
+            System.arraycopy(
+                    mask,
+                    0,
+                    maskedValue,
+                    fromIndex + i * mask.length,
+                    mask.length
+            );
+        }
+        // copy the suffix
+        System.arraycopy(
+                value,
+                fromIndex + length,
+                maskedValue,
+                maskedValue.length - suffixLength,
+                suffixLength
+        );
+
+        this.value = maskedValue;
+    }
+
+    @Override
+    public int countNonVisibleCharacters(int fromIndex, int length) {
+        return Utf8Util.countNonVisibleCharacters(value, fromIndex, length);
+    }
+
+    public String asString() {
+        return new String(value, StandardCharsets.UTF_8);
+    }
+}


### PR DESCRIPTION
Practical implementation for https://github.com/Breus/json-masker/pull/89#pullrequestreview-1926179868

TODO:
- [ ] Docs for all new functionality
- [ ] Performance to be comparable when using the `ValueMasker`
- [ ] Review naming of `ValueMasker` / `ValueMaskerContext`
- [ ] Decide on which maskers should be provided out of the box (this PR adds `ValueMasker.maskEmail` and `ValueMasker.maskStringWithFunction`)