### PR TITLE
Add actual withTextFunction that decodes / encodes JSON values

### DIFF
--- a/src/jmh/java/dev/blaauwendraad/masker/json/ValueMaskerBenchmark.java
+++ b/src/jmh/java/dev/blaauwendraad/masker/json/ValueMaskerBenchmark.java
@@ -38,11 +38,20 @@ public class ValueMaskerBenchmark {
                 .maskKeys(Set.of("targetKey"))
                 .build()
         );
-        private final JsonMasker functionalMasker = JsonMasker.getMasker(JsonMaskingConfig.builder()
+
+        private final JsonMasker rawValueMasker = JsonMasker.getMasker(JsonMaskingConfig.builder()
                 .maskKeys(Set.of("targetKey"))
                 .maskStringsWith(ValueMaskers.withRawValueFunction(value -> "\"***\""))
                 .maskNumbersWith(ValueMaskers.withRawValueFunction(value -> "\"###\""))
                 .maskBooleansWith(ValueMaskers.withRawValueFunction(value -> "\"&&&\""))
+                .build()
+        );
+
+        private final JsonMasker textValueMasker = JsonMasker.getMasker(JsonMaskingConfig.builder()
+                .maskKeys(Set.of("targetKey"))
+                .maskStringsWith(ValueMaskers.withTextFunction(value -> "***"))
+                .maskNumbersWith(ValueMaskers.withTextFunction(value -> "###"))
+                .maskBooleansWith(ValueMaskers.withTextFunction(value -> "&&&"))
                 .build()
         );
 
@@ -61,7 +70,12 @@ public class ValueMaskerBenchmark {
     }
 
     @Benchmark
-    public void maskWithFunctional(State state) {
-        state.functionalMasker.mask(state.jsonBytes);
+    public void maskWithRawValueFunction(State state) {
+        state.rawValueMasker.mask(state.jsonBytes);
+    }
+
+    @Benchmark
+    public void maskWithTextValueFunction(State state) {
+        state.textValueMasker.mask(state.jsonBytes);
     }
 }

--- a/src/main/java/dev/blaauwendraad/masker/json/InvalidJsonException.java
+++ b/src/main/java/dev/blaauwendraad/masker/json/InvalidJsonException.java
@@ -13,6 +13,7 @@ public class InvalidJsonException extends RuntimeException {
     public InvalidJsonException(String message, Throwable cause) {
         super(message, cause);
     }
+
     public InvalidJsonException(String message) {
         super(message);
     }

--- a/src/main/java/dev/blaauwendraad/masker/json/InvalidJsonException.java
+++ b/src/main/java/dev/blaauwendraad/masker/json/InvalidJsonException.java
@@ -13,4 +13,7 @@ public class InvalidJsonException extends RuntimeException {
     public InvalidJsonException(String message, Throwable cause) {
         super(message, cause);
     }
+    public InvalidJsonException(String message) {
+        super(message);
+    }
 }

--- a/src/main/java/dev/blaauwendraad/masker/json/MaskingState.java
+++ b/src/main/java/dev/blaauwendraad/masker/json/MaskingState.java
@@ -241,7 +241,7 @@ final class MaskingState implements ValueMaskerContext {
     @Override
     public InvalidJsonException invalidJson(String message, int index) {
         int offset = getCurrentValueStartIndex();
-        return new InvalidJsonException("'%s' at index %s".formatted(message, offset + index));
+        return new InvalidJsonException("%s at index %s".formatted(message, offset + index));
     }
 
     private void checkCurrentValueBounds(int index) {

--- a/src/main/java/dev/blaauwendraad/masker/json/MaskingState.java
+++ b/src/main/java/dev/blaauwendraad/masker/json/MaskingState.java
@@ -238,6 +238,12 @@ final class MaskingState implements ValueMaskerContext {
         return new String(message, offset + fromIndex, length, StandardCharsets.UTF_8);
     }
 
+    @Override
+    public InvalidJsonException invalidJson(String message, int index) {
+        int offset = getCurrentValueStartIndex();
+        return new InvalidJsonException("%s at index %s".formatted(message, offset + index));
+    }
+
     private void checkCurrentValueBounds(int index) {
         if (index < 0 || index >= byteLength()) {
             throw new IndexOutOfBoundsException("Index " + index + " is out of bounds for value of length " + byteLength());

--- a/src/main/java/dev/blaauwendraad/masker/json/MaskingState.java
+++ b/src/main/java/dev/blaauwendraad/masker/json/MaskingState.java
@@ -241,7 +241,7 @@ final class MaskingState implements ValueMaskerContext {
     @Override
     public InvalidJsonException invalidJson(String message, int index) {
         int offset = getCurrentValueStartIndex();
-        return new InvalidJsonException("%s at index %s".formatted(message, offset + index));
+        return new InvalidJsonException("'%s' at index %s".formatted(message, offset + index));
     }
 
     private void checkCurrentValueBounds(int index) {

--- a/src/main/java/dev/blaauwendraad/masker/json/ValueMaskerContext.java
+++ b/src/main/java/dev/blaauwendraad/masker/json/ValueMaskerContext.java
@@ -59,5 +59,13 @@ public interface ValueMaskerContext {
      */
     String asString(int fromIndex, int length);
 
+    /**
+     * Create an {@link InvalidJsonException} with the given message and index relative to the value (i.e. an index
+     * between {@code 0} and {@link ValueMaskerContext#byteLength()}).
+     *
+     * @param message error message
+     * @param index relative index where the JSON contains invalid sequence
+     * @return the exception to be thrown
+     */
     InvalidJsonException invalidJson(String message, int index);
 }

--- a/src/main/java/dev/blaauwendraad/masker/json/ValueMaskerContext.java
+++ b/src/main/java/dev/blaauwendraad/masker/json/ValueMaskerContext.java
@@ -58,4 +58,6 @@ public interface ValueMaskerContext {
      * Note: this INCLUDES the opening and closing quotes for string values 
      */
     String asString(int fromIndex, int length);
+
+    InvalidJsonException invalidJson(String message, int index);
 }

--- a/src/main/java/dev/blaauwendraad/masker/json/ValueMaskers.java
+++ b/src/main/java/dev/blaauwendraad/masker/json/ValueMaskers.java
@@ -337,7 +337,7 @@ public final class ValueMaskers {
                 "withTextFunction (%s)".formatted(masker),
                 context -> {
                     String decodedValue;
-                    if (context.byteLength() > 0 && context.getByte(0) == '"') {
+                    if (context.getByte(0) == '"') {
                         int encodedIndex = 1; // skip opening quote
                         int valueEndIndex = context.byteLength() - 1; // skip closing quote
                         int decodedIndex = 0;

--- a/src/main/java/dev/blaauwendraad/masker/json/ValueMaskers.java
+++ b/src/main/java/dev/blaauwendraad/masker/json/ValueMaskers.java
@@ -349,12 +349,12 @@ public final class ValueMaskers {
                                 originalByte = context.getByte(encodedIndex++);
                                 switch (originalByte) {
                                     // First, ones that are mapped
-                                    case 'b' -> decodedBytes[decodedIndex] = '\b';
-                                    case 't' -> decodedBytes[decodedIndex] = '\t';
-                                    case 'n' -> decodedBytes[decodedIndex] = '\n';
-                                    case 'f' -> decodedBytes[decodedIndex] = '\f';
-                                    case 'r' -> decodedBytes[decodedIndex] = '\r';
-                                    case '"', '/', '\\' -> decodedBytes[decodedIndex] = originalByte;
+                                    case 'b' -> decodedBytes[decodedIndex++] = '\b';
+                                    case 't' -> decodedBytes[decodedIndex++] = '\t';
+                                    case 'n' -> decodedBytes[decodedIndex++] = '\n';
+                                    case 'f' -> decodedBytes[decodedIndex++] = '\f';
+                                    case 'r' -> decodedBytes[decodedIndex++] = '\r';
+                                    case '"', '/', '\\' -> decodedBytes[decodedIndex++] = originalByte;
                                     case 'u' -> {
                                         // Decode Unicode character
                                         // the copy of String#encodeUTF8_UTF16 with the only difference that it
@@ -406,14 +406,12 @@ public final class ValueMaskers {
                                             decodedBytes[decodedIndex++] = (byte) (0x80 | ((c >> 6) & 0x3f));
                                             decodedBytes[decodedIndex++] = (byte) (0x80 | (c & 0x3f));
                                         }
-                                        continue;
                                     }
                                     default -> throw context.invalidJson("Unexpected character after '\\': '%s'".formatted((char) originalByte), encodedIndex);
                                 }
                             } else {
-                                decodedBytes[decodedIndex] = originalByte;
+                                decodedBytes[decodedIndex++] = originalByte;
                             }
-                            decodedIndex++;
                         }
                         decodedValue = new String(decodedBytes, 0, decodedIndex, StandardCharsets.UTF_8);
                     } else {

--- a/src/main/java/dev/blaauwendraad/masker/json/ValueMaskers.java
+++ b/src/main/java/dev/blaauwendraad/masker/json/ValueMaskers.java
@@ -397,13 +397,13 @@ public final class ValueMaskers {
                                             } else {
                                                 decodedBytes[decodedIndex++] = (byte) (0xf0 | (uc >> 18));
                                                 decodedBytes[decodedIndex++] = (byte) (0x80 | ((uc >> 12) & 0x3f));
-                                                decodedBytes[decodedIndex++] = (byte) (0x80 | ((uc >>  6) & 0x3f));
+                                                decodedBytes[decodedIndex++] = (byte) (0x80 | ((uc >> 6) & 0x3f));
                                                 decodedBytes[decodedIndex++] = (byte) (0x80 | (uc & 0x3f));
                                             }
                                         } else {
                                             // 3 bytes, 16 bits
                                             decodedBytes[decodedIndex++] = (byte) (0xe0 | (c >> 12));
-                                            decodedBytes[decodedIndex++] = (byte) (0x80 | ((c >>  6) & 0x3f));
+                                            decodedBytes[decodedIndex++] = (byte) (0x80 | ((c >> 6) & 0x3f));
                                             decodedBytes[decodedIndex++] = (byte) (0x80 | (c & 0x3f));
                                         }
                                         continue;

--- a/src/main/java/dev/blaauwendraad/masker/json/ValueMaskers.java
+++ b/src/main/java/dev/blaauwendraad/masker/json/ValueMaskers.java
@@ -323,7 +323,7 @@ public final class ValueMaskers {
      *     <td>{@code { "maskMe": "sec***" }}
      *   <tr>
      *     <td>{@code { "maskMe": "Andrii \"Juice\" Pilshchykov" }}
-     *     <td>{@code value -> value.replaceAll("\\\"", "(quote)")}
+     *     <td>{@code value -> value.replaceAll("\"", "(quote)")}
      *     <td>{@code { "maskMe": "Andrii (quote)Juice(quote) Pilshchykov" }}
      * </table>
      *

--- a/src/main/java/dev/blaauwendraad/masker/json/ValueMaskers.java
+++ b/src/main/java/dev/blaauwendraad/masker/json/ValueMaskers.java
@@ -341,6 +341,13 @@ public final class ValueMaskers {
                         int encodedIndex = 1; // skip opening quote
                         int valueEndIndex = context.byteLength() - 1; // skip closing quote
                         int decodedIndex = 0;
+                        // the length of decodedBytes is guaranteed to be lower or equal to the length
+                        // of the encoded bytes sequence:
+                        // 1. for every encoded character (2 bytes), the output is the character without escape - 1 byte
+                        // 2. for every unicode encoded character (6 bytes), the output character is within 1-3 bytes
+                        // 3. for the pair of unicode encoded surrogates (12 bytes), the output is always 4 bytes
+                        // which means that if any escape is present, the decodedBytes will have some null characters
+                        // at the tail, which are cut from the resulting string
                         byte[] decodedBytes = new byte[context.byteLength()];
                         while (encodedIndex < valueEndIndex) {
                             byte originalByte = context.getByte(encodedIndex++);

--- a/src/main/java/dev/blaauwendraad/masker/json/ValueMaskers.java
+++ b/src/main/java/dev/blaauwendraad/masker/json/ValueMaskers.java
@@ -395,14 +395,14 @@ public final class ValueMaskers {
                                                 throw context.invalidJson("Invalid surrogate pair '%s', expected '\\uXXXX\\uXXXX'"
                                                         .formatted(context.asString(valueStartIndex, encodedIndex - valueStartIndex)), valueStartIndex);
                                             } else {
-                                                decodedBytes[decodedIndex++] = (byte) (0xf0 | ((uc >> 18)));
+                                                decodedBytes[decodedIndex++] = (byte) (0xf0 | (uc >> 18));
                                                 decodedBytes[decodedIndex++] = (byte) (0x80 | ((uc >> 12) & 0x3f));
                                                 decodedBytes[decodedIndex++] = (byte) (0x80 | ((uc >>  6) & 0x3f));
                                                 decodedBytes[decodedIndex++] = (byte) (0x80 | (uc & 0x3f));
                                             }
                                         } else {
                                             // 3 bytes, 16 bits
-                                            decodedBytes[decodedIndex++] = (byte) (0xe0 | ((c >> 12)));
+                                            decodedBytes[decodedIndex++] = (byte) (0xe0 | (c >> 12));
                                             decodedBytes[decodedIndex++] = (byte) (0x80 | ((c >>  6) & 0x3f));
                                             decodedBytes[decodedIndex++] = (byte) (0x80 | (c & 0x3f));
                                         }

--- a/src/main/java/dev/blaauwendraad/masker/json/ValueMaskers.java
+++ b/src/main/java/dev/blaauwendraad/masker/json/ValueMaskers.java
@@ -323,6 +323,9 @@ public final class ValueMaskers {
                                                 }
                                             }
                                             if (uc < 0) {
+                                                // default String behaviour is to replace invalid surrogate pairs
+                                                // with the character '?', but from the JSON perspective,
+                                                // it's better to throw an exception
                                                 throw context.invalidJson("Invalid surrogate pair '%s', expected '\\uXXXX\\uXXXX'"
                                                         .formatted(context.asString(valueStartIndex, encodedIndex - valueStartIndex)), valueStartIndex);
                                             } else {

--- a/src/main/java/dev/blaauwendraad/masker/json/util/Utf8Util.java
+++ b/src/main/java/dev/blaauwendraad/masker/json/util/Utf8Util.java
@@ -31,12 +31,12 @@ public final class Utf8Util {
         throw new IllegalArgumentException("Input byte is not using UTF-8 encoding");
     }
 
-    public static int bytesToCodePoint(byte b1, byte b2, byte b3, byte b4) {
+    public static char unicodeToChar(byte b1, byte b2, byte b3, byte b4) {
         int value = Character.digit(Byte.toUnsignedInt(b1), 16);
-        value = (value << 4) | Character.digit(Byte.toUnsignedInt(b2), 16);;
-        value = (value << 4) | Character.digit(Byte.toUnsignedInt(b3), 16);;
-        value = (value << 4) | Character.digit(Byte.toUnsignedInt(b4), 16);;
-        return value;
+        value = (value << 4) | Character.digit(Byte.toUnsignedInt(b2), 16);
+        value = (value << 4) | Character.digit(Byte.toUnsignedInt(b3), 16);
+        value = (value << 4) | Character.digit(Byte.toUnsignedInt(b4), 16);
+        return (char) value;
     }
 
     /**

--- a/src/main/java/dev/blaauwendraad/masker/json/util/Utf8Util.java
+++ b/src/main/java/dev/blaauwendraad/masker/json/util/Utf8Util.java
@@ -31,7 +31,10 @@ public final class Utf8Util {
         throw new IllegalArgumentException("Input byte is not using UTF-8 encoding");
     }
 
-    public static char unicodeToChar(byte b1, byte b2, byte b3, byte b4) {
+    /**
+     * Converts a 4-byte UTF-8 encoded character ('\u0000') into a char.
+     */
+    public static char unicodeHexToChar(byte b1, byte b2, byte b3, byte b4) {
         int value = Character.digit(Byte.toUnsignedInt(b1), 16);
         value = (value << 4) | Character.digit(Byte.toUnsignedInt(b2), 16);
         value = (value << 4) | Character.digit(Byte.toUnsignedInt(b3), 16);

--- a/src/main/java/dev/blaauwendraad/masker/json/util/Utf8Util.java
+++ b/src/main/java/dev/blaauwendraad/masker/json/util/Utf8Util.java
@@ -33,13 +33,35 @@ public final class Utf8Util {
 
     /**
      * Converts a 4-byte UTF-8 encoded character ('\u0000') into a char.
+     * Each byte MUST represent a valid HEX character, i.e.
+     * <ul>
+     *     <li>in range from {@code 48} ({@code '0'}) to {@code 57} ({@code '9'})
+     *     <li>in range from {@code 65} ({@code 'A'}) to {@code 70} ({@code 'F'})
+     *     <li>in range from {@code 97} ({@code 'a'}) to {@code 102} ({@code 'f'})
+     * </ul>
      */
     public static char unicodeHexToChar(byte b1, byte b2, byte b3, byte b4) {
-        int value = Character.digit(Byte.toUnsignedInt(b1), 16);
-        value = (value << 4) | Character.digit(Byte.toUnsignedInt(b2), 16);
-        value = (value << 4) | Character.digit(Byte.toUnsignedInt(b3), 16);
-        value = (value << 4) | Character.digit(Byte.toUnsignedInt(b4), 16);
+        int value = Character.digit(validateHex(b1), 16);
+        // since each byte transformed into a value, that is guaranteed to be in range 0 - 16 (4 bits)
+        // we shift by that amount
+        value = (value << 4) | Character.digit(validateHex(b2), 16);
+        value = (value << 4) | Character.digit(validateHex(b3), 16);
+        value = (value << 4) | Character.digit(validateHex(b4), 16);
         return (char) value;
+    }
+
+    private static byte validateHex(byte hexByte) {
+        if (hexByte >= 48 && hexByte <= 57) {
+            return hexByte; // a digit from 0 to 9
+        }
+        if (hexByte >= 65 && hexByte <= 70) {
+            return hexByte; // a character from A to F
+        }
+        if (hexByte >= 97 && hexByte <= 102) {
+            return hexByte; // a character from a to f
+        }
+        throw new IllegalArgumentException("Invalid hex character '%s'".formatted((char) hexByte));
+
     }
 
     /**

--- a/src/main/java/dev/blaauwendraad/masker/json/util/Utf8Util.java
+++ b/src/main/java/dev/blaauwendraad/masker/json/util/Utf8Util.java
@@ -31,6 +31,14 @@ public final class Utf8Util {
         throw new IllegalArgumentException("Input byte is not using UTF-8 encoding");
     }
 
+    public static int bytesToCodePoint(byte b1, byte b2, byte b3, byte b4) {
+        int value = Character.digit(Byte.toUnsignedInt(b1), 16);
+        value = (value << 4) | Character.digit(Byte.toUnsignedInt(b2), 16);;
+        value = (value << 4) | Character.digit(Byte.toUnsignedInt(b3), 16);;
+        value = (value << 4) | Character.digit(Byte.toUnsignedInt(b4), 16);;
+        return value;
+    }
+
     /**
      * Counts the number of non-visible characters inside the string. The intervals provided must be
      * within a single string as this method will not do boundary checks or terminate at the end of

--- a/src/test/java/dev/blaauwendraad/masker/json/KeyMatcherTest.java
+++ b/src/test/java/dev/blaauwendraad/masker/json/KeyMatcherTest.java
@@ -171,7 +171,7 @@ final class KeyMatcherTest {
 
     @Test
     void shouldNotMatchPrefix() {
-        KeyMatcher keyMatcher = new KeyMatcher(JsonMaskingConfig.builder().maskKeys(Set.of("maskMe")).build());
+        KeyMatcher keyMatcher = new KeyMatcher(JsonMaskingConfig.builder().maskKeys(Set.of("maskMe", "test")).build());
         assertThatConfig(keyMatcher, "mask").isNull();
         assertThatConfig(keyMatcher, "maskMe").isNotNull();
     }

--- a/src/test/java/dev/blaauwendraad/masker/json/ValueMaskersTest.java
+++ b/src/test/java/dev/blaauwendraad/masker/json/ValueMaskersTest.java
@@ -213,6 +213,8 @@ class ValueMaskersTest {
                 .isEqualTo("\"not a secret\"");
         Assertions.assertThat(ByteValueMaskerContext.maskStringWith("secret: very much", valueMasker))
                 .isEqualTo("\"***\"");
+        Assertions.assertThat(ByteValueMaskerContext.maskStringWith("", valueMasker))
+                .isEqualTo("\"\"");
         Assertions.assertThat(ByteValueMaskerContext.maskNumberWith(12345, valueMasker))
                 .isEqualTo("\"12345\"");
         Assertions.assertThat(ByteValueMaskerContext.maskNumberWith(23456, valueMasker))

--- a/src/test/java/dev/blaauwendraad/masker/json/ValueMaskersTest.java
+++ b/src/test/java/dev/blaauwendraad/masker/json/ValueMaskersTest.java
@@ -307,6 +307,11 @@ class ValueMaskersTest {
                 .isInstanceOf(InvalidJsonException.class)
                         .hasMessageStartingWith("Invalid surrogate pair '\\uD83D', expected '\\uXXXX\\uXXXX' at index 1");
 
+        // high surrogate followed by another high surrogate
+        Assertions.assertThatThrownBy(() -> ByteValueMaskerContext.maskStringWith("\\uD83D\\uD83D", ValueMaskers.withTextFunction(value -> value)))
+                .isInstanceOf(InvalidJsonException.class)
+                .hasMessageStartingWith("Invalid surrogate pair '\\uD83D\\uD83D', expected '\\uXXXX\\uXXXX' at index 1");
+
         // high surrogate without low surrogate but other suffix
         Assertions.assertThatThrownBy(() -> ByteValueMaskerContext.maskStringWith("\\uD83Dsuffix", ValueMaskers.withTextFunction(value -> value)))
                 .isInstanceOf(InvalidJsonException.class)

--- a/src/test/java/dev/blaauwendraad/masker/json/ValueMaskersTest.java
+++ b/src/test/java/dev/blaauwendraad/masker/json/ValueMaskersTest.java
@@ -317,6 +317,11 @@ class ValueMaskersTest {
                 .isInstanceOf(InvalidJsonException.class)
                 .hasMessageStartingWith("Invalid surrogate pair '\\uD83D', expected '\\uXXXX\\uXXXX' at index 1");
 
+        // high surrogate without low surrogate but an escape character
+        Assertions.assertThatThrownBy(() -> ByteValueMaskerContext.maskStringWith("\\uD83D\n0000", ValueMaskers.withTextFunction(value -> value)))
+                .isInstanceOf(InvalidJsonException.class)
+                .hasMessageStartingWith("Invalid surrogate pair '\\uD83D', expected '\\uXXXX\\uXXXX' at index 1");
+
         // low surrogate without high surrogate
         Assertions.assertThatThrownBy(() -> ByteValueMaskerContext.maskStringWith("\\uDCA9", ValueMaskers.withTextFunction(value -> value)))
                 .isInstanceOf(InvalidJsonException.class)

--- a/src/test/java/dev/blaauwendraad/masker/json/ValueMaskersTest.java
+++ b/src/test/java/dev/blaauwendraad/masker/json/ValueMaskersTest.java
@@ -295,7 +295,9 @@ class ValueMaskersTest {
 
     @Test
     void withTextFunctionInvalidEscape() {
-        Assertions.assertThatThrownBy(() -> ByteValueMaskerContext.maskStringWith("\\z", ValueMaskers.withTextFunction(value -> value)))
+        ValueMasker.AnyValueMasker valueMasker = ValueMaskers.withTextFunction(value -> value);
+
+        Assertions.assertThatThrownBy(() -> ByteValueMaskerContext.maskStringWith("\\z", valueMasker))
                 .isInstanceOf(InvalidJsonException.class)
                 .hasMessage("Unexpected character after '\\': 'z' at index 3");
     }

--- a/src/test/java/dev/blaauwendraad/masker/json/ValueMaskersTest.java
+++ b/src/test/java/dev/blaauwendraad/masker/json/ValueMaskersTest.java
@@ -322,7 +322,7 @@ class ValueMaskersTest {
                 .hasMessage("Invalid surrogate pair '\\uD83D', expected '\\uXXXX\\uXXXX' at index 1");
 
         // high surrogate without low surrogate but an escape character
-        Assertions.assertThatThrownBy(() -> ByteValueMaskerContext.maskStringWith("\\uD83D\n0000", valueMasker))
+        Assertions.assertThatThrownBy(() -> ByteValueMaskerContext.maskStringWith("\\uD83D\\n0000", valueMasker))
                 .isInstanceOf(InvalidJsonException.class)
                 .hasMessage("Invalid surrogate pair '\\uD83D', expected '\\uXXXX\\uXXXX' at index 1");
 

--- a/src/test/java/dev/blaauwendraad/masker/json/ValueMaskersTest.java
+++ b/src/test/java/dev/blaauwendraad/masker/json/ValueMaskersTest.java
@@ -171,6 +171,26 @@ class ValueMaskersTest {
                 .isEqualTo("12345");
         Assertions.assertThat(ByteValueMaskerContext.maskBooleanWith(true, valueMasker))
                 .isEqualTo("true");
+        Assertions.assertThat(ByteValueMaskerContext.maskBooleanWith(true, ValueMaskers.withRawValueFunction(value -> null)))
+                .isEqualTo("null");
+    }
+
+    @Test
+    void withTextFunction() {
+        Assertions.assertThat(ByteValueMaskerContext.maskStringWith("\\u2020", ValueMaskers.withTextFunction(value -> {
+            Assertions.assertThat(value).isEqualTo("†");
+            return value;
+        }))).isEqualTo("\"†\""); // doesn't have to be encoded back
+
+        Assertions.assertThat(ByteValueMaskerContext.maskStringWith("\\uD800\\uDF48", ValueMaskers.withTextFunction(value -> {
+            Assertions.assertThat(value).isEqualTo("𐍈");
+            return value;
+        }))).isEqualTo("\"𐍈\""); // doesn't have to be encoded back
+
+        Assertions.assertThat(ByteValueMaskerContext.maskStringWith("\\n", ValueMaskers.withTextFunction(value -> {
+            Assertions.assertThat(value).isEqualTo("\n");
+            return value;
+        }))).isEqualTo("\"\\n\""); // needs to be escaped
     }
 
     @Test

--- a/src/test/java/dev/blaauwendraad/masker/json/ValueMaskersTest.java
+++ b/src/test/java/dev/blaauwendraad/masker/json/ValueMaskersTest.java
@@ -297,7 +297,7 @@ class ValueMaskersTest {
     void withTextFunctionInvalidEscape() {
         Assertions.assertThatThrownBy(() -> ByteValueMaskerContext.maskStringWith("\\z", ValueMaskers.withTextFunction(value -> value)))
                 .isInstanceOf(InvalidJsonException.class)
-                .hasMessageStartingWith("Unexpected character after '\\': 'z' at index 3");
+                .hasMessage("Unexpected character after '\\': 'z' at index 3");
     }
 
     @Test
@@ -307,32 +307,32 @@ class ValueMaskersTest {
         // high surrogate without low surrogate
         Assertions.assertThatThrownBy(() -> ByteValueMaskerContext.maskStringWith("\\uD83D", valueMasker))
                 .isInstanceOf(InvalidJsonException.class)
-                        .hasMessageStartingWith("Invalid surrogate pair '\\uD83D', expected '\\uXXXX\\uXXXX' at index 1");
+                        .hasMessage("Invalid surrogate pair '\\uD83D', expected '\\uXXXX\\uXXXX' at index 1");
 
         // high surrogate followed by another high surrogate
         Assertions.assertThatThrownBy(() -> ByteValueMaskerContext.maskStringWith("\\uD83D\\uD83D", valueMasker))
                 .isInstanceOf(InvalidJsonException.class)
-                .hasMessageStartingWith("Invalid surrogate pair '\\uD83D\\uD83D', expected '\\uXXXX\\uXXXX' at index 1");
+                .hasMessage("Invalid surrogate pair '\\uD83D\\uD83D', expected '\\uXXXX\\uXXXX' at index 1");
 
         // high surrogate without low surrogate but other suffix
         Assertions.assertThatThrownBy(() -> ByteValueMaskerContext.maskStringWith("\\uD83Dsuffix", valueMasker))
                 .isInstanceOf(InvalidJsonException.class)
-                .hasMessageStartingWith("Invalid surrogate pair '\\uD83D', expected '\\uXXXX\\uXXXX' at index 1");
+                .hasMessage("Invalid surrogate pair '\\uD83D', expected '\\uXXXX\\uXXXX' at index 1");
 
         // high surrogate without low surrogate but an escape character
         Assertions.assertThatThrownBy(() -> ByteValueMaskerContext.maskStringWith("\\uD83D\n0000", valueMasker))
                 .isInstanceOf(InvalidJsonException.class)
-                .hasMessageStartingWith("Invalid surrogate pair '\\uD83D', expected '\\uXXXX\\uXXXX' at index 1");
+                .hasMessage("Invalid surrogate pair '\\uD83D', expected '\\uXXXX\\uXXXX' at index 1");
 
         // low surrogate without high surrogate
         Assertions.assertThatThrownBy(() -> ByteValueMaskerContext.maskStringWith("\\uDCA9", valueMasker))
                 .isInstanceOf(InvalidJsonException.class)
-                .hasMessageStartingWith("Invalid surrogate pair '\\uDCA9', expected '\\uXXXX\\uXXXX' at index 1");
+                .hasMessage("Invalid surrogate pair '\\uDCA9', expected '\\uXXXX\\uXXXX' at index 1");
 
         // low surrogate without high surrogate but other prefix
         Assertions.assertThatThrownBy(() -> ByteValueMaskerContext.maskStringWith("prefix\\uDCA9", valueMasker))
                 .isInstanceOf(InvalidJsonException.class)
-                .hasMessageStartingWith("Invalid surrogate pair '\\uDCA9', expected '\\uXXXX\\uXXXX' at index 7");
+                .hasMessage("Invalid surrogate pair '\\uDCA9', expected '\\uXXXX\\uXXXX' at index 7");
     }
 
     @Test

--- a/src/test/java/dev/blaauwendraad/masker/json/ValueMaskersTest.java
+++ b/src/test/java/dev/blaauwendraad/masker/json/ValueMaskersTest.java
@@ -302,33 +302,35 @@ class ValueMaskersTest {
 
     @Test
     void withTextFunctionInvalidUnicode() {
+        ValueMasker.AnyValueMasker valueMasker = ValueMaskers.withTextFunction(value -> value);
+
         // high surrogate without low surrogate
-        Assertions.assertThatThrownBy(() -> ByteValueMaskerContext.maskStringWith("\\uD83D", ValueMaskers.withTextFunction(value -> value)))
+        Assertions.assertThatThrownBy(() -> ByteValueMaskerContext.maskStringWith("\\uD83D", valueMasker))
                 .isInstanceOf(InvalidJsonException.class)
                         .hasMessageStartingWith("Invalid surrogate pair '\\uD83D', expected '\\uXXXX\\uXXXX' at index 1");
 
         // high surrogate followed by another high surrogate
-        Assertions.assertThatThrownBy(() -> ByteValueMaskerContext.maskStringWith("\\uD83D\\uD83D", ValueMaskers.withTextFunction(value -> value)))
+        Assertions.assertThatThrownBy(() -> ByteValueMaskerContext.maskStringWith("\\uD83D\\uD83D", valueMasker))
                 .isInstanceOf(InvalidJsonException.class)
                 .hasMessageStartingWith("Invalid surrogate pair '\\uD83D\\uD83D', expected '\\uXXXX\\uXXXX' at index 1");
 
         // high surrogate without low surrogate but other suffix
-        Assertions.assertThatThrownBy(() -> ByteValueMaskerContext.maskStringWith("\\uD83Dsuffix", ValueMaskers.withTextFunction(value -> value)))
+        Assertions.assertThatThrownBy(() -> ByteValueMaskerContext.maskStringWith("\\uD83Dsuffix", valueMasker))
                 .isInstanceOf(InvalidJsonException.class)
                 .hasMessageStartingWith("Invalid surrogate pair '\\uD83D', expected '\\uXXXX\\uXXXX' at index 1");
 
         // high surrogate without low surrogate but an escape character
-        Assertions.assertThatThrownBy(() -> ByteValueMaskerContext.maskStringWith("\\uD83D\n0000", ValueMaskers.withTextFunction(value -> value)))
+        Assertions.assertThatThrownBy(() -> ByteValueMaskerContext.maskStringWith("\\uD83D\n0000", valueMasker))
                 .isInstanceOf(InvalidJsonException.class)
                 .hasMessageStartingWith("Invalid surrogate pair '\\uD83D', expected '\\uXXXX\\uXXXX' at index 1");
 
         // low surrogate without high surrogate
-        Assertions.assertThatThrownBy(() -> ByteValueMaskerContext.maskStringWith("\\uDCA9", ValueMaskers.withTextFunction(value -> value)))
+        Assertions.assertThatThrownBy(() -> ByteValueMaskerContext.maskStringWith("\\uDCA9", valueMasker))
                 .isInstanceOf(InvalidJsonException.class)
                 .hasMessageStartingWith("Invalid surrogate pair '\\uDCA9', expected '\\uXXXX\\uXXXX' at index 1");
 
         // low surrogate without high surrogate but other prefix
-        Assertions.assertThatThrownBy(() -> ByteValueMaskerContext.maskStringWith("prefix\\uDCA9", ValueMaskers.withTextFunction(value -> value)))
+        Assertions.assertThatThrownBy(() -> ByteValueMaskerContext.maskStringWith("prefix\\uDCA9", valueMasker))
                 .isInstanceOf(InvalidJsonException.class)
                 .hasMessageStartingWith("Invalid surrogate pair '\\uDCA9', expected '\\uXXXX\\uXXXX' at index 7");
     }

--- a/src/test/java/dev/blaauwendraad/masker/json/path/JsonPathTest.java
+++ b/src/test/java/dev/blaauwendraad/masker/json/path/JsonPathTest.java
@@ -17,4 +17,15 @@ class JsonPathTest {
         Assertions.assertNull(jsonPath.getQueryArgument());
     }
 
+    @Test
+    void shouldCheckSegmentsOnEquals() {
+        JsonPath a = new JsonPath(new String[]{"a", "b"});
+        JsonPath b = new JsonPath(new String[]{"a", "b"});
+
+        Assertions.assertEquals(a, a);
+        Assertions.assertEquals(a, b);
+        Assertions.assertEquals(a.hashCode(), b.hashCode());
+        Assertions.assertNotEquals(a, null);
+    }
+
 }

--- a/src/test/java/dev/blaauwendraad/masker/json/util/ByteValueMaskerContext.java
+++ b/src/test/java/dev/blaauwendraad/masker/json/util/ByteValueMaskerContext.java
@@ -118,7 +118,7 @@ public class ByteValueMaskerContext implements ValueMaskerContext {
 
     @Override
     public InvalidJsonException invalidJson(String message, int index) {
-        return new InvalidJsonException("%s at index %s".formatted(message, index));
+        return new InvalidJsonException("'%s' at index %s".formatted(message, index));
     }
 
     public String getMaskedValue() {

--- a/src/test/java/dev/blaauwendraad/masker/json/util/ByteValueMaskerContext.java
+++ b/src/test/java/dev/blaauwendraad/masker/json/util/ByteValueMaskerContext.java
@@ -1,5 +1,6 @@
 package dev.blaauwendraad.masker.json.util;
 
+import dev.blaauwendraad.masker.json.InvalidJsonException;
 import dev.blaauwendraad.masker.json.ValueMasker;
 import dev.blaauwendraad.masker.json.ValueMaskerContext;
 
@@ -113,6 +114,11 @@ public class ByteValueMaskerContext implements ValueMaskerContext {
     @Override
     public String asString(int fromIndex, int length) {
         return new String(value, fromIndex, length, StandardCharsets.UTF_8);
+    }
+
+    @Override
+    public InvalidJsonException invalidJson(String message, int index) {
+        return new InvalidJsonException("%s at index %s".formatted(message, index));
     }
 
     public String getMaskedValue() {

--- a/src/test/java/dev/blaauwendraad/masker/json/util/ByteValueMaskerContext.java
+++ b/src/test/java/dev/blaauwendraad/masker/json/util/ByteValueMaskerContext.java
@@ -118,7 +118,7 @@ public class ByteValueMaskerContext implements ValueMaskerContext {
 
     @Override
     public InvalidJsonException invalidJson(String message, int index) {
-        return new InvalidJsonException("'%s' at index %s".formatted(message, index));
+        return new InvalidJsonException("%s at index %s".formatted(message, index));
     }
 
     public String getMaskedValue() {

--- a/src/test/java/dev/blaauwendraad/masker/json/util/Utf8UtilTest.java
+++ b/src/test/java/dev/blaauwendraad/masker/json/util/Utf8UtilTest.java
@@ -54,6 +54,10 @@ class Utf8UtilTest {
         Assertions.assertThatThrownBy(() -> Utf8Util.unicodeHexToChar((byte) 71, (byte) '0', (byte) '2', (byte) '0'))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("Invalid hex character 'G'");
+
+        Assertions.assertThatThrownBy(() -> Utf8Util.unicodeHexToChar((byte) 103, (byte) '0', (byte) '2', (byte) '0'))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Invalid hex character 'g'");
     }
 
     @ParameterizedTest

--- a/src/test/java/dev/blaauwendraad/masker/json/util/Utf8UtilTest.java
+++ b/src/test/java/dev/blaauwendraad/masker/json/util/Utf8UtilTest.java
@@ -31,6 +31,31 @@ class Utf8UtilTest {
                 .isThrownBy(() -> Utf8Util.getCodePointByteLength((byte) (b << 1)));
     }
 
+    @Test
+    void unicodeHexToChar() {
+        Assertions.assertThat(Utf8Util.unicodeHexToChar((byte) '0', (byte) '0', (byte) '2', (byte) '0'))
+                .isEqualTo(' ');
+        Assertions.assertThat(Utf8Util.unicodeHexToChar((byte) '0', (byte) '0', (byte) '3', (byte) '0'))
+                .isEqualTo('0');
+        Assertions.assertThat(Utf8Util.unicodeHexToChar((byte) '0', (byte) '0', (byte) '4', (byte) '0'))
+                .isEqualTo('@');
+    }
+
+    @Test
+    void unicodeHexToCharInvalid() {
+        Assertions.assertThatThrownBy(() -> Utf8Util.unicodeHexToChar((byte) 35, (byte) '0', (byte) '2', (byte) '0'))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Invalid hex character '#'");
+
+        Assertions.assertThatThrownBy(() -> Utf8Util.unicodeHexToChar((byte) 61, (byte) '0', (byte) '2', (byte) '0'))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Invalid hex character '='");
+
+        Assertions.assertThatThrownBy(() -> Utf8Util.unicodeHexToChar((byte) 71, (byte) '0', (byte) '2', (byte) '0'))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Invalid hex character 'G'");
+    }
+
     @ParameterizedTest
     @MethodSource("unicodeCharactersLength")
     void unicodeCharacters(String character, int utf8ByteLength) {


### PR DESCRIPTION
This PR adds a function that will actually decode / encode the JSON string into Java string and back.
Decoding would be simple if not for `\uXXXX` that need to be decoded. It also doesn't help that we're working on byte level, so that I needed to convert 4 byte -> int -> 1-2 chars -> 1-4 bytes. That code is like magic at this point because 
1. ~~ChatGPT wrote most of it (from many tries)~~ took me a while to actually understand the original code, so instead now it's almost a full copy of `String#encodeUTF8_UTF16` 😝 
2. I wrote the some of it after finding bunch of problems

In my defense, it does match (somewhat) the magic done in [Jackson](https://github.com/FasterXML/jackson-core/blob/2.18/src/main/java/com/fasterxml/jackson/core/json/UTF8JsonGenerator.java#L2123-L2134) and [String#encodeUTF8_UTF16](https://github.com/openjdk/jdk/blob/jdk-21%2B35/src/java.base/share/classes/java/lang/String.java#L1322-L1374) 😅 

Encoding is simple as it's only escapes necessary characters without encoding unicode symbols into `\uXXXX` (that's allowed)