### PR TITLE
Make sure pipelines run from forks

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,6 +1,6 @@
 name: Benchmarks
 on:
-  pull_request:
+  pull_request_target:
     branches:
       - master
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,7 @@ on:
       - master
     tags-ignore:
       - '*'
-  pull_request:
+  pull_request_target:
     branches:
       - master
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,9 +5,10 @@ on:
       - master
     tags-ignore:
       - '*'
-  pull_request_target:
+  pull_request:
     branches:
       - master
+  workflow_dispatch:
 
 concurrency:
   # On master, we don't want any jobs cancelled so the sha is used to name the group


### PR DESCRIPTION
To make sure that workflow run and finish correctly, we're using the [pull_request_target](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target). This runs the PR with full privileges, but it doesn't allow modifying the pipeline itself from the PR.
It's safe to run the benchmark pipeline in `pull_request_target` as it doesn't have access to the secrets, however our `build` pipeline explicitly propagates secrets when runs gradle, therefore it would be possible for the PR pipeline to do `System.getenv` and expose the secret values.