### PR TITLE
Fix benchmark exception when we have less than 20 unambiguous json paths

### DIFF
--- a/src/test/java/dev/blaauwendraad/masker/json/util/JsonPathTestUtils.java
+++ b/src/test/java/dev/blaauwendraad/masker/json/util/JsonPathTestUtils.java
@@ -76,7 +76,7 @@ public class JsonPathTestUtils {
         }
         List<String> allKeys = disambiguate(new ArrayList<>(transformedTargetKeys));
         Collections.shuffle(allKeys, new Random(RandomJsonGenerator.STATIC_RANDOM_SEED));
-        return new HashSet<>(allKeys.subList(0, keys.size()));
+        return new HashSet<>(allKeys.subList(0, Math.min(keys.size(), allKeys.size())));
     }
 
     /**


### PR DESCRIPTION
Noticed this when benchmarked against ascii