### PR TITLE
Fix matching JSON keys longer than 256 bytes

### DIFF
--- a/src/test/java/dev/blaauwendraad/masker/json/KeyMatcherTest.java
+++ b/src/test/java/dev/blaauwendraad/masker/json/KeyMatcherTest.java
@@ -227,6 +227,13 @@ final class KeyMatcherTest {
                 .isEqualTo("\"[redacted]\"");
     }
 
+    @Test
+    void shouldAllowVeryLargeKeys() {
+        String key = "k".repeat(10000);
+        KeyMatcher keyMatcher = new KeyMatcher(JsonMaskingConfig.builder().maskKeys(Set.of(key)).build());
+        assertThatConfig(keyMatcher, key).isNotNull();
+    }
+
     private ObjectAssert<KeyMaskingConfig> assertThatConfig(KeyMatcher keyMatcher, String key) {
         byte[] bytes = key.getBytes(StandardCharsets.UTF_8);
         return Assertions.assertThat(keyMatcher.getMaskConfigIfMatched(bytes, 0, bytes.length, null));


### PR DESCRIPTION
This was meant as optimization for the total key lengths, but currently it fails on long keys instead. This PR makes it that if any key of length >= 255 exists, then we start matching