### PR TITLE
Replace JsonPATH stack with a separate JsonPATH trie

### DIFF
--- a/src/test/java/dev/blaauwendraad/masker/json/MaskingStateTest.java
+++ b/src/test/java/dev/blaauwendraad/masker/json/MaskingStateTest.java
@@ -5,7 +5,6 @@ import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.nio.charset.StandardCharsets;
-import java.util.Set;
 
 class MaskingStateTest {
     @Test
@@ -14,7 +13,7 @@ class MaskingStateTest {
                 {
                     "maskMe": "some value"
                 }
-                """.getBytes(StandardCharsets.UTF_8), false);
+                """.getBytes(StandardCharsets.UTF_8));
 
         Assertions.assertThat(maskingState).hasToString("""
                 >{<
@@ -45,18 +44,9 @@ class MaskingStateTest {
     }
 
     @Test
-    void jsonPathExceedsCapacity() {
-        MaskingState maskingState = new MaskingState("[]".getBytes(StandardCharsets.UTF_8), true);
-        for (int i = 0; i < 101; i++) {
-            maskingState.expandCurrentJsonPath(new KeyMatcher.TrieNode());
-        }
-        Assertions.assertThat(maskingState.getCurrentJsonPathNode()).isNotNull();
-    }
-
-    @Test
     void getCurrentJsonPathNodeFromEmptyJsonPath() {
-        MaskingState maskingState = new MaskingState("[]".getBytes(StandardCharsets.UTF_8), true);
-        Assertions.assertThat(maskingState.getCurrentJsonPathNode()).isNull();
+        MaskingState maskingState = new MaskingState("[]".getBytes(StandardCharsets.UTF_8));
+        Assertions.assertThat(maskingState.getCurrentJsonPathHead()).isNull();
     }
 
     @Test
@@ -65,7 +55,7 @@ class MaskingStateTest {
                 {
                     "maskMe": "some value"
                 }
-                """.getBytes(StandardCharsets.UTF_8), false);
+                """.getBytes(StandardCharsets.UTF_8));
 
         Assertions.assertThatThrownBy(() -> maskingState.getCurrentValueStartIndex())
                 .isInstanceOf(IllegalStateException.class);

--- a/src/test/resources/test-json-path.json
+++ b/src/test/resources/test-json-path.json
@@ -1626,5 +1626,41 @@
         }
       }
     }
+  },
+  {
+    "maskingConfig": {
+      "maskJsonPaths": [
+        "$.aa"
+      ]
+    },
+    "input": {"a":"do not mask","aa": "mask"},
+    "expectedOutput": {"a":"do not mask","aa": "***"}
+  },
+  {
+    "maskingConfig": {
+      "allowJsonPaths": [
+        "$.aa"
+      ]
+    },
+    "input": {"a":"mask","aa": "do not mask"},
+    "expectedOutput": {"a":"***","aa": "do not mask"}
+  },
+  {
+    "maskingConfig": {
+      "maskJsonPaths": [
+        "$.a"
+      ]
+    },
+    "input": {"a":"mask","aa": "do not mask"},
+    "expectedOutput": {"a":"***","aa": "do not mask"}
+  },
+  {
+    "maskingConfig": {
+      "allowJsonPaths": [
+        "$.a"
+      ]
+    },
+    "input": {"a":"do not mask","aa": "mask"},
+    "expectedOutput": {"a":"do not mask","aa": "***"}
   }
 ]


### PR DESCRIPTION
The change replaces a stack-based implementation of JsonPATH tracking with a trie-based. The end-of-segment nodes of the trie have a reference to the parent segment. Every time the current JsonPATH is backtracked, the head is moved onto the parent segment of the current segment.