### PR TITLE
Filter out other GC metrics

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -57,12 +57,12 @@ jobs:
         
           ### Benchmark results (pull-request, ${{ github.event.pull_request.head.sha }})
           \`\`\`text
-          $(cat benchmark-pull-request/build/results/jmh/results.txt)
+          $(grep -vE ':gc.(alloc.rate|count|time)\s' benchmark-pull-request/build/results/jmh/results.txt)
           \`\`\`
           
           ### Benchmark results (${{ github.base_ref }}, ${{ steps.get-master-sha.outputs.sha }})
           \`\`\`text
-          $(cat benchmark-master/build/results/jmh/results.txt)
+          $(grep -vE ':gc.(alloc.rate|count|time)\s' benchmark-master/build/results/jmh/results.txt)
           \`\`\`
           EOF
 


### PR DESCRIPTION
This PR adds a filter to only include `:gc.alloc.rate.norm`:
```text
Benchmark                                                          (characters)  (jsonPath)  (jsonSize)  (maskedKeyProbability)   Mode  Cnt        Score        Error   Units
BaselineBenchmark.countBytes                                            unicode         N/A         1kb                     0.1  thrpt    4  2607351.452 ± 136045.820   ops/s
BaselineBenchmark.countBytes:gc.alloc.rate.norm                         unicode         N/A         1kb                     0.1  thrpt    4       ≈ 10⁻⁴                 B/op
BaselineBenchmark.jacksonParseAndMask                                   unicode         N/A         1kb                     0.1  thrpt    4    29755.556 ±   1519.193   ops/s
BaselineBenchmark.jacksonParseAndMask:gc.alloc.rate.norm                unicode         N/A         1kb                     0.1  thrpt    4    65184.007 ±      0.009    B/op
BaselineBenchmark.jacksonParseOnly                                      unicode         N/A         1kb                     0.1  thrpt    4    50755.172 ±   1005.338   ops/s
BaselineBenchmark.jacksonParseOnly:gc.alloc.rate.norm                   unicode         N/A         1kb                     0.1  thrpt    4    24352.004 ±      0.001    B/op
BaselineBenchmark.regexReplace                                          unicode         N/A         1kb                     0.1  thrpt    4     3296.232 ±    157.298   ops/s
BaselineBenchmark.regexReplace:gc.alloc.rate.norm                       unicode         N/A         1kb                     0.1  thrpt    4    61656.055 ±      0.013    B/op
JsonMaskerBenchmark.jsonMaskerBytes                                     unicode       false         1kb                     0.1  thrpt    4   452984.607 ±   5704.565   ops/s
JsonMaskerBenchmark.jsonMaskerBytes:gc.alloc.rate.norm                  unicode       false         1kb                     0.1  thrpt    4     2232.000 ±      0.001    B/op
JsonMaskerBenchmark.jsonMaskerBytes                                     unicode        true         1kb                     0.1  thrpt    4   610665.329 ±  16237.866   ops/s
JsonMaskerBenchmark.jsonMaskerBytes:gc.alloc.rate.norm                  unicode        true         1kb                     0.1  thrpt    4     1280.000 ±      0.001    B/op
JsonMaskerBenchmark.jsonMaskerString                                    unicode       false         1kb                     0.1  thrpt    4   240769.068 ±   7813.396   ops/s
JsonMaskerBenchmark.jsonMaskerString:gc.alloc.rate.norm                 unicode       false         1kb                     0.1  thrpt    4    10136.001 ±      0.001    B/op
JsonMaskerBenchmark.jsonMaskerString                                    unicode        true         1kb                     0.1  thrpt    4   258901.255 ±   2116.657   ops/s
JsonMaskerBenchmark.jsonMaskerString:gc.alloc.rate.norm                 unicode        true         1kb                     0.1  thrpt    4    10312.001 ±      0.001    B/op
ValueMaskerBenchmark.maskWithRawValueFunction                           unicode         N/A         1kb                     0.1  thrpt    4   657444.024 ±  15865.346   ops/s
ValueMaskerBenchmark.maskWithRawValueFunction:gc.alloc.rate.norm        unicode         N/A         1kb                     0.1  thrpt    4     1592.000 ±      0.001    B/op
ValueMaskerBenchmark.maskWithStatic                                     unicode         N/A         1kb                     0.1  thrpt    4   777206.195 ±  19800.097   ops/s
ValueMaskerBenchmark.maskWithStatic:gc.alloc.rate.norm                  unicode         N/A         1kb                     0.1  thrpt    4     1232.000 ±      0.001    B/op
ValueMaskerBenchmark.maskWithTextValueFunction                          unicode         N/A         1kb                     0.1  thrpt    4   625349.074 ±  21004.992   ops/s
ValueMaskerBenchmark.maskWithTextValueFunction:gc.alloc.rate.norm       unicode         N/A         1kb                     0.1  thrpt    4     1880.000 ±      0.001    B/op
```
> [!NOTE]
> It won't be visible on this PR comment due to `pull_request_target` event