### PR TITLE
Implement input/output streaming support

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,18 +7,22 @@
 [![Sonar Coverage](https://img.shields.io/sonar/coverage/Breus_json-masker?server=https%3A%2F%2Fsonarcloud.io&color=appveyor&style=flat-square)](https://sonarcloud.io/project/overview?id=Breus_json-masker)
 [![Sonar Tests](https://img.shields.io/sonar/total_tests/Breus_json-masker?server=https%3A%2F%2Fsonarcloud.io&style=flat-square)](https://sonarcloud.io/project/overview?id=Breus_json-masker)
 
-JSON masker library which can be used to mask (sensitive) values inside JSON corresponding to a set of keys (**block-mode**)
-or, alternatively, allow only specific values to be unmasked corresponding to a set of keys while all others are
-masked (**allow-mode**).
+JSON Masker library allows for highly flexible masking of sensitive data in JSON, supporting two modes:
 
-The library provides modern and convenient Java APIs which offers a wide range of masking customizations.
-Furthermore, the implementation is focused on maximizing the throughput and minimizing heap memory allocations to minimize
-GC pressure.
+* Block Mode: Mask values corresponding to a specified set of keys.
+* Allow Mode: Unmask only the values corresponding to specified keys, while masking all others.
 
-Finally, no additional third-party runtime dependencies are required to use this library.
+The library provides modern and convenient Java APIs, offering extensive masking customizations. It includes both 
+streaming and in-memory APIs to cater to various use cases.
+
+The library is designed for high throughput and efficient memory usage, it minimizes heap allocations to reduce GC 
+pressure.
+
+Finally, no additional third-party runtime dependencies  are required to use this library.
 
 ## Features
 
+* Mask a user-provided stream of JSON and write it to a user-provided output stream 
 * Mask all primitive values by specifying the keys to mask, by default any `string` is masked as `"***"`, any `number`
   as `"###"` and any `boolean` as `"&&&"`
 * If the value of a targeted key corresponds to an `object`, all nested fields, including nested arrays and objects will
@@ -330,6 +334,23 @@ String maskedJson = jsonMasker.mask(json);
   }
 }
 ```
+
+### Masking with the streaming API
+To mask (potentially) large JSON input, the streaming API can be used. 
+
+All features of the JsonMasker work exactly the same for the streaming API and the (default) in-memory API. 
+
+#### Usage
+```java
+var jsonMasker = JsonMasker.getMasker(
+        JsonMaskingConfig.builder()
+                .maskKeys(Set.of("email", "iban"))
+                .build()
+);
+
+jsonMasker.mask(jsonInputStream, jsonOutputStream);
+```
+
 
 ### Masking with JSONPath
 
@@ -730,9 +751,7 @@ String maskedJson = jsonMasker.mask(json);
 
 ## Dependencies
 
-* **The library has no third-party runtime dependencies**
-* The library only has a single JSR-305 compilation dependency for nullability annotations
-* The test/benchmark dependencies for this library are listed in the `build.gradle`
+**The library has no third-party runtime dependencies**
 
 ## Performance
 

--- a/src/jmh/java/dev/blaauwendraad/masker/json/BaselineBenchmark.java
+++ b/src/jmh/java/dev/blaauwendraad/masker/json/BaselineBenchmark.java
@@ -11,10 +11,14 @@ import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.TearDown;
 import org.openjdk.jmh.annotations.Warmup;
 
+import java.io.FileWriter;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
@@ -54,6 +58,11 @@ public class BaselineBenchmark {
                     .map(key -> Pattern.compile("(\"" + key + "\"\\s*:\\s*)(\"?[^\"]*\"?)", Pattern.CASE_INSENSITIVE))
                     .toList();
         }
+
+        @TearDown
+        public synchronized void tearDown() throws IOException {
+            Files.deleteIfExists(Path.of("file.json"));
+        }
     }
 
     @Benchmark
@@ -63,6 +72,13 @@ public class BaselineBenchmark {
             sum += state.jsonBytes[i];
         }
         return sum;
+    }
+
+    @Benchmark
+    public void writeFile(State state) throws IOException {
+        try (FileWriter fileWriter = new FileWriter("file.json")) {
+            fileWriter.write(state.jsonString);
+        }
     }
 
     @Benchmark

--- a/src/jmh/java/dev/blaauwendraad/masker/json/JsonMaskerBenchmark.java
+++ b/src/jmh/java/dev/blaauwendraad/masker/json/JsonMaskerBenchmark.java
@@ -14,6 +14,8 @@ import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.Warmup;
 import dev.blaauwendraad.masker.json.util.JsonPathTestUtils;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
@@ -65,5 +67,10 @@ public class JsonMaskerBenchmark {
     @Benchmark
     public byte[] jsonMaskerBytes(State state) {
         return state.jsonMasker.mask(state.jsonBytes);
+    }
+
+    @Benchmark
+    public void jsonMaskerByteArrayStreams(State state) {
+        state.jsonMasker.mask(new ByteArrayInputStream(state.jsonBytes), new ByteArrayOutputStream());
     }
 }

--- a/src/jmh/java/dev/blaauwendraad/masker/json/StreamTypeBenchmark.java
+++ b/src/jmh/java/dev/blaauwendraad/masker/json/StreamTypeBenchmark.java
@@ -1,0 +1,105 @@
+package dev.blaauwendraad.masker.json;
+
+import dev.blaauwendraad.masker.json.config.JsonMaskingConfig;
+import dev.blaauwendraad.masker.json.util.JsonPathTestUtils;
+import org.jspecify.annotations.NullUnmarked;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+@Warmup(iterations = 1, time = 3)
+@Fork(value = 1)
+@Measurement(iterations = 1, time = 3)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@BenchmarkMode(Mode.Throughput)
+public class StreamTypeBenchmark {
+
+    static final String INPUT_FILE_STREAM_NAME = "input.json";
+    static final String OUTPUT_FILE_STREAM_NAME = "output.json";
+
+    @org.openjdk.jmh.annotations.State(Scope.Thread)
+    @NullUnmarked
+    public static class State {
+        @Param({"ByteArrayStream", "FileStream"})
+        String streamInputType;
+        @Param({"ByteArrayStream", "FileStream"})
+        String streamOutputType;
+        @Param({"10mb"})
+        String jsonSize;
+
+        byte[] json;
+
+        private JsonMasker jsonMasker;
+
+        @Setup
+        public synchronized void setup() throws IOException {
+            // prepare a json
+            Set<String> targetKeys = BenchmarkUtils.getTargetKeys(20);
+            json = BenchmarkUtils.randomJson(targetKeys, jsonSize, "unicode", 0.1).getBytes(StandardCharsets.UTF_8);
+
+            // prepare an input file for FileStreams
+            try (FileWriter inputFileWriter = new FileWriter(INPUT_FILE_STREAM_NAME)) {
+                inputFileWriter.write(new String(json, StandardCharsets.UTF_8));
+                inputFileWriter.flush();
+            }
+
+            // create a masker
+            JsonMaskingConfig.Builder builder = JsonMaskingConfig.builder();
+            builder.maskJsonPaths(JsonPathTestUtils.transformToJsonPathKeys(targetKeys, new String(json, StandardCharsets.UTF_8)));
+
+            jsonMasker = JsonMasker.getMasker(builder.build());
+        }
+
+        @TearDown
+        public synchronized void tearDown() throws IOException {
+            Files.deleteIfExists(Path.of(INPUT_FILE_STREAM_NAME));
+            Files.deleteIfExists(Path.of(OUTPUT_FILE_STREAM_NAME));
+        }
+    }
+
+    private InputStream createInputStream(byte[] json, String inputStreamType) throws IOException {
+        return switch (inputStreamType) {
+            case "ByteArrayStream" -> new ByteArrayInputStream(json);
+            case "FileStream" -> new FileInputStream(INPUT_FILE_STREAM_NAME);
+            default -> throw new IllegalArgumentException("Unknown stream type");
+        };
+    }
+
+    private OutputStream createOutputStream(String outputStreamType) throws IOException {
+        return switch (outputStreamType) {
+            case "ByteArrayStream" -> new ByteArrayOutputStream();
+            case "FileStream" -> new FileOutputStream(OUTPUT_FILE_STREAM_NAME);
+            default -> throw new IllegalArgumentException("Unknown stream type");
+        };
+    }
+
+    @Benchmark
+    public void jsonMaskerStreams(State state) throws IOException {
+        try (InputStream inputStream = createInputStream(state.json, state.streamInputType);
+             OutputStream outputStream = createOutputStream(state.streamOutputType)) {
+            state.jsonMasker.mask(inputStream, outputStream);
+        }
+    }
+}

--- a/src/main/java/dev/blaauwendraad/masker/json/JsonMasker.java
+++ b/src/main/java/dev/blaauwendraad/masker/json/JsonMasker.java
@@ -4,6 +4,7 @@ import dev.blaauwendraad.masker.json.config.JsonMaskingConfig;
 
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
 import java.util.Set;
 
@@ -44,8 +45,11 @@ public interface JsonMasker {
     /**
      * Masks the given JSON input stream and writes the result into the output stream.
      *
-     * @param inputStream the JSON input stream
+     * @param inputStream  the JSON input stream
      * @param outputStream masked JSON output stream
+     * @throws InvalidJsonException in case invalid JSON input was provided
+     * @throws UncheckedIOException if an I/O error occurs while reading from the input stream or writing to the output
+     *                              stream
      */
     void mask(InputStream inputStream, OutputStream outputStream);
 

--- a/src/main/java/dev/blaauwendraad/masker/json/JsonMasker.java
+++ b/src/main/java/dev/blaauwendraad/masker/json/JsonMasker.java
@@ -2,6 +2,8 @@ package dev.blaauwendraad.masker.json;
 
 import dev.blaauwendraad.masker.json.config.JsonMaskingConfig;
 
+import java.io.InputStream;
+import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.Set;
 
@@ -38,6 +40,14 @@ public interface JsonMasker {
      * @throws InvalidJsonException in case invalid JSON input was provided
      */
     byte[] mask(byte[] input);
+
+    /**
+     * Masks the given JSON input stream and writes the result into the output stream.
+     *
+     * @param inputStream the JSON input stream
+     * @param outputStream masked JSON output stream
+     */
+    void mask(InputStream inputStream, OutputStream outputStream);
 
     /**
      * Masks the given JSON input and returns the masked output.

--- a/src/main/java/dev/blaauwendraad/masker/json/KeyContainsMasker.java
+++ b/src/main/java/dev/blaauwendraad/masker/json/KeyContainsMasker.java
@@ -19,6 +19,7 @@ final class KeyContainsMasker implements JsonMasker {
     private final KeyMatcher keyMatcher;
     /**
      * The masking configuration for the JSON masking process.
+     * Package private for unit tests.
      */
     final JsonMaskingConfig maskingConfig;
 

--- a/src/main/java/dev/blaauwendraad/masker/json/MaskingState.java
+++ b/src/main/java/dev/blaauwendraad/masker/json/MaskingState.java
@@ -1,8 +1,10 @@
 package dev.blaauwendraad.masker.json;
-
 import dev.blaauwendraad.masker.json.util.Utf8Util;
 import org.jspecify.annotations.Nullable;
-
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -14,10 +16,18 @@ import java.util.List;
  */
 final class MaskingState implements ValueMaskerContext {
     private static final int INITIAL_JSONPATH_STACK_CAPACITY = 16; // an initial size of the jsonpath array
-    private final byte[] message;
+    private static final String STREAM_READ_ERROR_MESSAGE = "Failed to read from input stream";
+    private static final String STREAM_WRITE_ERROR_MESSAGE = "Failed to write to output stream";
+
+    private byte[] message;
+    private int messageLength;
+    private int bufferSize; // size of byte array buffers to be read from the input stream
     private int currentIndex = 0;
     private final List<ReplacementOperation> replacementOperations = new ArrayList<>();
+    private int lastReplacementEndIndex = 0;
     private int replacementOperationsTotalDifference = 0;
+    @Nullable private final InputStream inputStream;
+    @Nullable private final OutputStream outputStream;
 
     /**
      * Current JSONPath is represented by a stack of segment references.
@@ -25,17 +35,43 @@ final class MaskingState implements ValueMaskerContext {
      */
     private KeyMatcher.@Nullable TrieNode @Nullable [] currentJsonPath = null;
     private int currentJsonPathHeadIndex = -1;
-    private int currentValueStartIndex = -1;
+    private int currentTokenStartIndex = -1;
 
     public MaskingState(byte[] message, boolean trackJsonPath) {
         this.message = message;
+        this.messageLength = message.length;
         if (trackJsonPath) {
             currentJsonPath = new KeyMatcher.TrieNode[INITIAL_JSONPATH_STACK_CAPACITY];
         }
+        this.inputStream = null;
+        this.outputStream = null;
+    }
+
+    public MaskingState(InputStream inputStream, OutputStream outputStream, boolean trackJsonPath, int bufferSize) {
+        /*
+         There is a special optimization for "true", "false" and "null" values. We identify such values by their first
+         character ("t", "f" and "n" respectively) and assume the identified value length. When masker is in allow mode,
+         we may step over these values. In case the buffer size is less than the maximum possible length of such
+         "special" value, we end up stepping over the entire buffer. To mitigate that, we force the minimum buffer size
+         to be the maximum possible length, which is 5 (in "false").
+        */
+        if (bufferSize < 5) {
+            throw new IllegalArgumentException("Buffer size must be at least 5 bytes");
+        }
+
+        this.inputStream = inputStream;
+        this.outputStream = outputStream;
+        this.bufferSize = bufferSize;
+        this.message = new byte[this.bufferSize];
+        this.messageLength = 0;
+        if (trackJsonPath) {
+            currentJsonPath = new KeyMatcher.TrieNode[INITIAL_JSONPATH_STACK_CAPACITY];
+        }
+        readNextBuffer();
     }
 
     public boolean next() {
-        return ++currentIndex < message.length;
+        return ++currentIndex < messageLength || reloadBuffer();
     }
 
     public void incrementIndex(int length) {
@@ -47,7 +83,7 @@ final class MaskingState implements ValueMaskerContext {
     }
 
     public boolean endOfJson() {
-        return currentIndex >= message.length;
+        return currentIndex >= messageLength && !reloadBuffer();
     }
 
     public int currentIndex() {
@@ -66,9 +102,25 @@ final class MaskingState implements ValueMaskerContext {
      * @see ReplacementOperation
      */
     public void replaceTargetValueWith(int startIndex, int length, byte[] mask, int maskRepeat) {
-        ReplacementOperation replacementOperation = new ReplacementOperation(startIndex, length, mask, maskRepeat);
-        replacementOperations.add(replacementOperation);
-        replacementOperationsTotalDifference += replacementOperation.difference();
+        if (outputStream == null) {
+            ReplacementOperation replacementOperation = new ReplacementOperation(startIndex, length, mask, maskRepeat);
+            replacementOperations.add(replacementOperation);
+            replacementOperationsTotalDifference += replacementOperation.difference();
+        } else {
+            // write the replacement into the output stream
+            try {
+                // write everything up to the beginning of the current replacement
+                outputStream.write(message, lastReplacementEndIndex, startIndex - lastReplacementEndIndex);
+
+                // write the replacement
+                for (int i = 0; i < maskRepeat; i++) {
+                    outputStream.write(mask);
+                }
+            } catch (IOException e) {
+                throw new UncheckedIOException(STREAM_WRITE_ERROR_MESSAGE, e);
+            }
+            lastReplacementEndIndex = startIndex + length;
+        }
     }
 
     /**
@@ -90,7 +142,7 @@ final class MaskingState implements ValueMaskerContext {
         // Create new empty array with a length computed by the difference of all mismatches of lengths between the target values and the masks
         // in some edge cases the length difference might be equal to 0, but since some indices mismatch (otherwise there would be no replacement operations)
         // we still have to copy the array to keep track of data according to original indices
-        byte[] newMessage = new byte[message.length + replacementOperationsTotalDifference];
+        byte[] newMessage = new byte[messageLength + replacementOperationsTotalDifference];
 
         // Index of the original message array
         int index = 0;
@@ -128,11 +180,8 @@ final class MaskingState implements ValueMaskerContext {
                 index,
                 newMessage,
                 index + offset,
-                message.length - index
+                messageLength - index
         );
-
-        // make sure no operations are performed after this
-        this.currentIndex = Integer.MAX_VALUE;
 
         return newMessage;
     }
@@ -180,43 +229,51 @@ final class MaskingState implements ValueMaskerContext {
         }
     }
 
-    public int getCurrentValueStartIndex() {
-        if (currentValueStartIndex == -1) {
+    boolean isCurrentTokenRegistered() {
+        return currentTokenStartIndex != -1;
+    }
+
+    public int getCurrentTokenStartIndex() {
+        if (!isCurrentTokenRegistered()) {
             throw new IllegalStateException("No current value index set to mask");
         }
-        return currentValueStartIndex;
+        return currentTokenStartIndex;
     }
 
     /**
-     * Register the current index as the start index of the value to be masked.
+     * Register the current index as the start index of the token. The token could be either a key or a value of type
+     * "string", "number", "boolean" or null.
      */
-    public void registerValueStartIndex() {
-        this.currentValueStartIndex = currentIndex;
+    public void registerTokenStartIndex() {
+        this.currentTokenStartIndex = currentIndex;
     }
 
     /**
-     * Clears the previous registered value start index.
+     * Clears the previous registered token start index.
      */
-    public void clearValueStartIndex() {
-        this.currentValueStartIndex = -1;
+    public void clearTokenStartIndex() {
+        this.currentTokenStartIndex = -1;
     }
 
     @Override
     public byte getByte(int index) {
         checkCurrentValueBounds(index);
-        return message[getCurrentValueStartIndex() + index];
+        return message[getCurrentTokenStartIndex() + index];
     }
 
     @Override
     public int byteLength() {
-        return Math.min(currentIndex, message.length) - getCurrentValueStartIndex();
+        if (messageLength <= currentIndex) {
+            reloadBuffer();
+        }
+        return Math.min(currentIndex, messageLength) - getCurrentTokenStartIndex();
     }
 
     @Override
     public void replaceBytes(int fromIndex, int length, byte[] mask, int maskRepeat) {
         checkCurrentValueBounds(fromIndex);
         checkCurrentValueBounds(fromIndex + length - 1);
-        replaceTargetValueWith(getCurrentValueStartIndex() + fromIndex, length, mask, maskRepeat);
+        replaceTargetValueWith(getCurrentTokenStartIndex() + fromIndex, length, mask, maskRepeat);
     }
 
     @Override
@@ -225,7 +282,7 @@ final class MaskingState implements ValueMaskerContext {
         checkCurrentValueBounds(fromIndex + length - 1);
         return Utf8Util.countNonVisibleCharacters(
                 message,
-                getCurrentValueStartIndex() + fromIndex,
+                getCurrentTokenStartIndex() + fromIndex,
                 length
         );
     }
@@ -234,13 +291,13 @@ final class MaskingState implements ValueMaskerContext {
     public String asString(int fromIndex, int length) {
         checkCurrentValueBounds(fromIndex);
         checkCurrentValueBounds(fromIndex + length - 1);
-        int offset = getCurrentValueStartIndex();
+        int offset = getCurrentTokenStartIndex();
         return new String(message, offset + fromIndex, length, StandardCharsets.UTF_8);
     }
 
     @Override
     public InvalidJsonException invalidJson(String message, int index) {
-        int offset = getCurrentValueStartIndex();
+        int offset = getCurrentTokenStartIndex();
         return new InvalidJsonException("%s at index %s".formatted(message, offset + index));
     }
 
@@ -250,19 +307,113 @@ final class MaskingState implements ValueMaskerContext {
         }
     }
 
+    /**
+     * Flushes the current buffer into provided OutputStream, then moves the current token to the beginning of the buffer
+     * and fills up the buffer from provided InputStream.
+     * In case the current token is too long (the start index is not in the last quarter of the buffer),
+     * extends the current buffer by 2.
+     *
+     * @return true if more data is available in the input stream, false if the end of the stream is reached.
+     */
+    boolean reloadBuffer() {
+        flushCurrentBuffer();
+        return readNextBuffer();
+    }
+
+    /**
+     * Flushes the remaining of the current buffer up to the current token start index into output stream
+     */
+    void flushCurrentBuffer() {
+        if (outputStream == null) {
+            return;
+        }
+        try {
+            int remainingBufferLength = !isCurrentTokenRegistered() ?
+                    messageLength - lastReplacementEndIndex : // flush the remaining of the message
+                    currentTokenStartIndex - lastReplacementEndIndex; // flush the remaining of the message up to the current token start index
+            outputStream.write(message, lastReplacementEndIndex, remainingBufferLength);
+            outputStream.flush();
+            lastReplacementEndIndex = 0;
+        } catch (IOException e) {
+            throw new UncheckedIOException(STREAM_READ_ERROR_MESSAGE, e);
+        }
+    }
+
+    /**
+     * Reads the next buffer and extends the buffer size if necessary.
+     *
+     * @return true if more data is available in the stream, false otherwise
+     */
+    private boolean readNextBuffer() {
+        if (inputStream == null) {
+            return false;
+        }
+        if (!isCurrentTokenRegistered()) {
+            // the pointer is not at a json value, so we are safe to read the next buffer
+            currentIndex -= messageLength;
+            try {
+                messageLength = inputStream.readNBytes(message, 0, bufferSize);
+            } catch (IOException e) {
+                throw new UncheckedIOException(STREAM_READ_ERROR_MESSAGE, e);
+            }
+        } else {
+            // the current buffer has ended before the masker finished processing the current value.
+            int currentTokenLength = messageLength - currentTokenStartIndex;
+            moveCurrentTokenToBeginningOfBuffer(currentTokenLength);
+
+            // fill up the remaining of the buffer
+            try {
+                messageLength = inputStream.readNBytes(message, currentTokenLength, bufferSize - currentTokenLength) + currentTokenLength;
+            } catch (IOException e) {
+                throw new UncheckedIOException(STREAM_READ_ERROR_MESSAGE, e);
+            }
+
+            // reset pointers
+            currentIndex -= currentTokenStartIndex;
+            currentTokenStartIndex = 0;
+        }
+        return messageLength > currentIndex;
+    }
+
+    /**
+     * Moves the current token to the beginning of buffer. If current token size is larger than a quarter of the buffer size,
+     * extends the buffer size by 2
+     */
+    private void moveCurrentTokenToBeginningOfBuffer(int currentTokenLength) {
+        if (currentTokenLength < bufferSize >> 2) {
+            // in case the current value is shorter than a quarter of the buffer,
+            // fill up the buffer without extending its length
+
+            // move the current value to the beginning of the buffer
+            System.arraycopy(message, currentTokenStartIndex, message, 0, currentTokenLength);
+        } else {
+            // in case the current value is longer than a quarter of the buffer,
+            // extend the buffer length by a quarter
+            bufferSize <<= 1;
+            if (bufferSize >= 65536) {
+                throw new IllegalStateException("Buffer overflow");
+            }
+            byte[] extension = new byte[bufferSize];
+
+            // move the current value to the beginning of the extension
+            System.arraycopy(message, currentTokenStartIndex, extension, 0, currentTokenLength);
+            message = extension;
+        }
+    }
+
     // for debugging purposes, shows the current state of message traversal
     @Override
     public String toString() {
         StringBuilder sb = new StringBuilder();
         sb.append(new String(message, Math.max(0, currentIndex - 10), Math.min(10, currentIndex), StandardCharsets.UTF_8));
         sb.append(">");
-        if (endOfJson()) {
-            sb.append("<end of json>");
+        if (currentIndex >= messageLength) {
+            sb.append("<end of buffer>");
         } else {
             sb.append((char) message[currentIndex]);
-            if (currentIndex + 1 < message.length) {
+            if (currentIndex + 1 < messageLength) {
                 sb.append("<");
-                sb.append(new String(message, currentIndex + 1, Math.min(10, message.length - currentIndex - 1), StandardCharsets.UTF_8));
+                sb.append(new String(message, currentIndex + 1, Math.min(10, messageLength - currentIndex - 1), StandardCharsets.UTF_8));
             }
         }
         return sb.toString();

--- a/src/main/java/dev/blaauwendraad/masker/json/config/JsonMaskingConfig.java
+++ b/src/main/java/dev/blaauwendraad/masker/json/config/JsonMaskingConfig.java
@@ -35,6 +35,7 @@ public final class JsonMaskingConfig {
     private final boolean caseSensitiveTargetKeys;
     /**
      * Not configurable. Specifies the initial size of the byte array buffer in streaming mode
+     * Package private for unit tests
      */
     int bufferSize = 8192;
 
@@ -66,7 +67,7 @@ public final class JsonMaskingConfig {
      * Checks if the target key mode is set to "ALLOW". If the mode is set to "ALLOW", it means that the target keys are
      * interpreted as the only JSON keys for which the corresponding property is allowed (should not be masked).
      *
-     * @return true if the target key mode is set to "ALLOW", false otherwise
+     * @return {@code true} if the target key mode is set to "ALLOW", {@code false} otherwise
      */
     public boolean isInAllowMode() {
         return targetKeyMode == TargetKeyMode.ALLOW;
@@ -76,7 +77,7 @@ public final class JsonMaskingConfig {
      * Checks if the target key mode is set to "MASK". If the mode is set to "MASK", it means that the properties
      * corresponding to the target keys should be masked.
      *
-     * @return true if the current target key mode is in "MASK" mode, false otherwise
+     * @return {@code true} if the current target key mode is in "MASK" mode, {@code false} otherwise
      */
     public boolean isInMaskMode() {
         return targetKeyMode == TargetKeyMode.MASK;
@@ -93,7 +94,7 @@ public final class JsonMaskingConfig {
     /**
      * Tests if target keys should be considered case-sensitive.
      *
-     * @return true if target keys are considered case-sensitive and false otherwise.
+     * @return {@code true} if target keys are considered case-sensitive, {@code false} otherwise.
      */
     public boolean caseSensitiveTargetKeys() {
         return caseSensitiveTargetKeys;

--- a/src/main/java/dev/blaauwendraad/masker/json/config/JsonMaskingConfig.java
+++ b/src/main/java/dev/blaauwendraad/masker/json/config/JsonMaskingConfig.java
@@ -33,6 +33,10 @@ public final class JsonMaskingConfig {
      * @see JsonMaskingConfig.Builder#caseSensitiveTargetKeys
      */
     private final boolean caseSensitiveTargetKeys;
+    /**
+     * Not configurable. Specifies the initial size of the byte array buffer in streaming mode
+     */
+    int bufferSize = 8192;
 
     private final KeyMaskingConfig defaultConfig;
     private final Map<String, KeyMaskingConfig> targetKeyConfigs;
@@ -93,6 +97,10 @@ public final class JsonMaskingConfig {
      */
     public boolean caseSensitiveTargetKeys() {
         return caseSensitiveTargetKeys;
+    }
+
+    public int bufferSize() {
+        return bufferSize;
     }
 
     /**

--- a/src/main/java/dev/blaauwendraad/masker/json/util/AsciiCharacter.java
+++ b/src/main/java/dev/blaauwendraad/masker/json/util/AsciiCharacter.java
@@ -51,7 +51,7 @@ public enum AsciiCharacter {
      * Tests if the given byte corresponds to a double quote '{@literal "}' in ASCII encoding.
      *
      * @param inputByte the input byte
-     * @return true if the byte corresponds to a double quote in ASCII encoding and false otherwise.
+     * @return {@code true} if the byte corresponds to a double quote in ASCII encoding, {@code false} otherwise
      */
     public static boolean isDoubleQuote(byte inputByte) {
         return DOUBLE_QUOTE.getAsciiByteValue() == inputByte;
@@ -61,8 +61,8 @@ public enum AsciiCharacter {
      * Tests if the given byte corresponds to an escape character (backslash) '\' in ASCII encoding.
      *
      * @param inputByte the input byte
-     * @return true if the byte corresponds to an escape character (backslash) in ASCII encoding and
-     *     false otherwise.
+     * @return {@code true} if the byte corresponds to an escape character (backslash) in ASCII encoding, {@code false}
+     * otherwise
      */
     public static boolean isEscapeCharacter(byte inputByte) {
         return BACK_SLASH.getAsciiByteValue() == inputByte;
@@ -72,8 +72,7 @@ public enum AsciiCharacter {
      * Tests if the given byte corresponds to a lowercase 'u' in ASCII encoding.
      *
      * @param inputByte the input byte
-     * @return true if the byte corresponds to a lowercase 'u' in ASCII encoding and false
-     *     otherwise.
+     * @return {@code true} if the byte corresponds to a lowercase 'u' in ASCII encoding, {@code false} otherwise
      */
     public static boolean isLowercaseU(byte inputByte) {
         return LOWERCASE_U.getAsciiByteValue() == inputByte;
@@ -83,20 +82,19 @@ public enum AsciiCharacter {
      * Tests if the given byte corresponds to an opening square bracket '[' in ASCII encoding.
      *
      * @param inputByte the input byte
-     * @return true if the byte corresponds to an opening square bracket '[' in ASCII encoding and
-     *     false otherwise.
+     * @return {@code true} if the byte corresponds to an opening square bracket '[' in ASCII encoding, {@code false}
+     * otherwise
      */
     public static boolean isSquareBracketOpen(byte inputByte) {
         return SQUARE_BRACKET_OPEN.getAsciiByteValue() == inputByte;
     }
 
     /**
-     * Tests if the given byte corresponds to a closing square bracket '{@literal ]}' in ASCII
-     * encoding.
+     * Tests if the given byte corresponds to a closing square bracket '{@literal ]}' in ASCII encoding.
      *
      * @param inputByte the input byte
-     * @return true if the byte corresponds to a closing square bracket '{@literal ]}' in ASCII
-     *     encoding and false otherwise.
+     * @return {@code true} if the byte corresponds to a closing square bracket '{@literal ]}' in ASCII encoding,
+     * {@code false} otherwise
      */
     public static boolean isSquareBracketClose(byte inputByte) {
         return SQUARE_BRACKET_CLOSE.getAsciiByteValue() == inputByte;
@@ -107,8 +105,8 @@ public enum AsciiCharacter {
      * encoding.
      *
      * @param inputByte the input byte
-     * @return true if the byte corresponds to an opening curly bracket '{@literal {}}' in ASCII
-     *     encoding and false otherwise.i
+     * @return {@code true} if the byte corresponds to an opening curly bracket '{@literal {}}' in ASCII
+     *     encoding, {@code false} otherwise
      */
     public static boolean isCurlyBracketOpen(byte inputByte) {
         return CURLY_BRACKET_OPEN.getAsciiByteValue() == inputByte;
@@ -119,8 +117,8 @@ public enum AsciiCharacter {
      * encoding.
      *
      * @param inputByte the input byte
-     * @return true if the byte corresponds to a closing curly bracket '{@literal }}' in ASCII
-     *     encoding and false otherwise.
+     * @return {@code true} if the byte corresponds to a closing curly bracket '{@literal }}' in ASCII
+     *     encoding, {@code false} otherwise
      */
     public static boolean isCurlyBracketClose(byte inputByte) {
         return CURLY_BRACKET_CLOSE.getAsciiByteValue() == inputByte;
@@ -130,8 +128,8 @@ public enum AsciiCharacter {
      * Tests if the given byte corresponds to a lower case t 't' in ASCII encoding.
      *
      * @param inputByte the input byte
-     * @return true if the byte corresponds to a lower case t 't' in ASCII encoding and false
-     *     otherwise.
+     * @return {@code true} if the byte corresponds to a lower case t 't' in ASCII encoding, {@code false}
+     *     otherwise
      */
     public static boolean isLowercaseT(byte inputByte) {
         return LOWERCASE_T.getAsciiByteValue() == inputByte;

--- a/src/test/java/dev/blaauwendraad/masker/json/AllowModeTest.java
+++ b/src/test/java/dev/blaauwendraad/masker/json/AllowModeTest.java
@@ -1,21 +1,20 @@
 package dev.blaauwendraad.masker.json;
 
 import dev.blaauwendraad.masker.json.config.JsonMaskingConfig;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import java.io.IOException;
 import java.util.stream.Stream;
 
-import static org.assertj.core.api.Assertions.assertThat;
 
 final class AllowModeTest {
 
     @ParameterizedTest
     @MethodSource("testAllowMode")
     void targetKeyAllowMode(JsonMaskerTestInstance testInstance) {
-        assertThat(testInstance.jsonMasker().mask(testInstance.input())).isEqualTo(testInstance.expectedOutput());
+        JsonMaskerTestUtil.assertJsonMaskerApiEquivalence(testInstance.jsonMasker(), testInstance.input(),
+                testInstance.expectedOutput());
     }
 
     private static Stream<JsonMaskerTestInstance> testAllowMode() throws IOException {
@@ -25,8 +24,8 @@ final class AllowModeTest {
     @ParameterizedTest
     @MethodSource("targetKeyAllowModeNotPretty")
     void targetKeyAllowModeNotPretty(JsonMaskerTestInstance testInstance) {
-        Assertions.assertThat(testInstance.jsonMasker().mask(testInstance.input()))
-                .isEqualTo(testInstance.expectedOutput());
+        JsonMaskerTestUtil.assertJsonMaskerApiEquivalence(testInstance.jsonMasker(), testInstance.input(),
+                testInstance.expectedOutput());
     }
 
     private static Stream<JsonMaskerTestInstance> targetKeyAllowModeNotPretty() {

--- a/src/test/java/dev/blaauwendraad/masker/json/AssumedLengthValuesTest.java
+++ b/src/test/java/dev/blaauwendraad/masker/json/AssumedLengthValuesTest.java
@@ -1,0 +1,28 @@
+package dev.blaauwendraad.masker.json;
+
+import dev.blaauwendraad.masker.json.config.JsonMaskingConfig;
+import org.junit.jupiter.api.Test;
+
+/**
+ * The test suite covers masking of values whose length is assumed by the masker: "true", "false" and "null"
+ */
+class AssumedLengthValuesTest {
+    @Test
+    void shouldMaskConstantSizeValues() {
+        JsonMaskingConfig config = JsonMaskingConfig.builder().maskKeys("mask").build();
+        JsonMasker jsonMasker = JsonMasker.getMasker(config);
+
+        JsonMaskerTestUtil.assertJsonMaskerApiEquivalence(jsonMasker, "{\"mask\":false}", "{\"mask\":\"&&&\"}");
+        JsonMaskerTestUtil.assertJsonMaskerApiEquivalence(jsonMasker, "{\"mask\":true}", "{\"mask\":\"&&&\"}");
+        JsonMaskerTestUtil.assertJsonMaskerApiEquivalence(jsonMasker, "{\"mask\":null}", "{\"mask\":null}");
+    }
+    @Test
+    void shouldAllowConstantSizeValuesInMaskMode() {
+        JsonMaskingConfig config = JsonMaskingConfig.builder().allowKeys("mask").build();
+        JsonMasker jsonMasker = JsonMasker.getMasker(config);
+
+        JsonMaskerTestUtil.assertJsonMaskerApiEquivalence(jsonMasker, "{\"mask\":false}", "{\"mask\":false}");
+        JsonMaskerTestUtil.assertJsonMaskerApiEquivalence(jsonMasker, "{\"mask\":true}", "{\"mask\":true}");
+        JsonMaskerTestUtil.assertJsonMaskerApiEquivalence(jsonMasker, "{\"mask\":null}", "{\"mask\":null}");
+    }
+}

--- a/src/test/java/dev/blaauwendraad/masker/json/ColonInKeyOrValueTest.java
+++ b/src/test/java/dev/blaauwendraad/masker/json/ColonInKeyOrValueTest.java
@@ -6,14 +6,14 @@ import org.junit.jupiter.params.provider.MethodSource;
 import java.io.IOException;
 import java.util.stream.Stream;
 
-import static org.assertj.core.api.Assertions.assertThat;
 
 class ColonInKeyOrValueTest {
 
     @ParameterizedTest
     @MethodSource("testContainsColonFile")
     void containsColon(JsonMaskerTestInstance testInstance) {
-        assertThat(testInstance.jsonMasker().mask(testInstance.input())).isEqualTo(testInstance.expectedOutput());
+        JsonMaskerTestUtil.assertJsonMaskerApiEquivalence(testInstance.jsonMasker(), testInstance.input(),
+                testInstance.expectedOutput());
     }
 
     private static Stream<JsonMaskerTestInstance> testContainsColonFile() throws IOException {

--- a/src/test/java/dev/blaauwendraad/masker/json/CustomKeyMaskingConfigTest.java
+++ b/src/test/java/dev/blaauwendraad/masker/json/CustomKeyMaskingConfigTest.java
@@ -2,9 +2,11 @@ package dev.blaauwendraad.masker.json;
 
 import dev.blaauwendraad.masker.json.config.JsonMaskingConfig;
 import dev.blaauwendraad.masker.json.config.KeyMaskingConfig;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import java.util.Set;
 
@@ -19,7 +21,7 @@ class CustomKeyMaskingConfigTest {
                 .maskJsonPaths(Set.of("$.stringPath", "$.numberPath", "$.booleanPath"))
                 .build());
 
-        String masked = jsonMasker.mask("""
+        JsonMaskerTestUtil.assertJsonMaskerApiEquivalence(jsonMasker, """
                 {
                   "string": "maskMe",
                   "stringPath": "maskMe",
@@ -28,8 +30,7 @@ class CustomKeyMaskingConfigTest {
                   "boolean": false,
                   "booleanPath": false
                 }
-                """);
-        Assertions.assertThat(masked).isEqualTo("""
+                """, """
                 {
                   "string": "***",
                   "stringPath": "***",
@@ -38,8 +39,7 @@ class CustomKeyMaskingConfigTest {
                   "boolean": "&&&",
                   "booleanPath": "&&&"
                 }
-                """
-        );
+                """);
     }
 
     @Test
@@ -52,7 +52,7 @@ class CustomKeyMaskingConfigTest {
                 .maskBooleansWith("(boolean)")
                 .build());
 
-        String masked = jsonMasker.mask("""
+        JsonMaskerTestUtil.assertJsonMaskerApiEquivalence(jsonMasker, """
                 {
                   "string": "maskMe",
                   "stringPath": "maskMe",
@@ -61,8 +61,7 @@ class CustomKeyMaskingConfigTest {
                   "boolean": false,
                   "booleanPath": false
                 }
-                """);
-        Assertions.assertThat(masked).isEqualTo("""
+                """, """
                 {
                   "string": "(string)",
                   "stringPath": "(string)",
@@ -71,8 +70,7 @@ class CustomKeyMaskingConfigTest {
                   "boolean": "(boolean)",
                   "booleanPath": "(boolean)"
                 }
-                """
-        );
+                """);
     }
 
     @Test
@@ -94,7 +92,7 @@ class CustomKeyMaskingConfigTest {
                 )
                 .build());
 
-        String masked = jsonMasker.mask("""
+        JsonMaskerTestUtil.assertJsonMaskerApiEquivalence(jsonMasker, """
                 {
                   "string": "maskMe",
                   "stringPath": "maskMe",
@@ -109,8 +107,7 @@ class CustomKeyMaskingConfigTest {
                   "booleanCustom": false,
                   "booleanPathCustom": false
                 }
-                """);
-        Assertions.assertThat(masked).isEqualTo("""
+                """, """
                 {
                   "string": "***",
                   "stringPath": "***",
@@ -125,8 +122,7 @@ class CustomKeyMaskingConfigTest {
                   "booleanCustom": "(boolean)",
                   "booleanPathCustom": "(boolean)"
                 }
-                """
-        );
+                """);
     }
 
     @Test
@@ -147,7 +143,7 @@ class CustomKeyMaskingConfigTest {
                 ))
                 .build());
 
-        String masked = jsonMasker.mask("""
+        JsonMaskerTestUtil.assertJsonMaskerApiEquivalence(jsonMasker, """
                 {
                   "a": {
                     "string": "maskMe",
@@ -175,9 +171,7 @@ class CustomKeyMaskingConfigTest {
                     }
                   }
                 }
-                """);
-
-        Assertions.assertThat(masked).isEqualTo("""
+                """, """
                 {
                   "a": {
                     "string": "***",
@@ -226,7 +220,7 @@ class CustomKeyMaskingConfigTest {
                 ))
                 .build());
 
-        String masked = jsonMasker.mask("""
+        JsonMaskerTestUtil.assertJsonMaskerApiEquivalence(jsonMasker, """
                 {
                   "a": {
                     "string": "maskMe",
@@ -254,9 +248,7 @@ class CustomKeyMaskingConfigTest {
                     }
                   }
                 }
-                """);
-
-        Assertions.assertThat(masked).isEqualTo("""
+                """, """
                 {
                   "a": {
                     "string": "***",
@@ -309,7 +301,7 @@ class CustomKeyMaskingConfigTest {
                 )
                 .build());
 
-        String masked = jsonMasker.mask("""
+        JsonMaskerTestUtil.assertJsonMaskerApiEquivalence(jsonMasker, """
                 {
                   "string": "maskMe",
                   "number": 12345,
@@ -319,8 +311,7 @@ class CustomKeyMaskingConfigTest {
                   "emailSuffixOnly": "agavlyukovskiy@gmail.com",
                   "emailDomainOnly": "agavlyukovskiy@gmail.com"
                 }
-                """);
-        Assertions.assertThat(masked).isEqualTo("""
+                """, """
                 {
                   "string": "***",
                   "number": "###",
@@ -330,8 +321,7 @@ class CustomKeyMaskingConfigTest {
                   "emailSuffixOnly": "***om",
                   "emailDomainOnly": "***@gmail.com"
                 }
-                """
-        );
+                """);
     }
 
     @Test
@@ -356,7 +346,7 @@ class CustomKeyMaskingConfigTest {
                 )
                 .build());
 
-        String masked = jsonMasker.mask("""
+        JsonMaskerTestUtil.assertJsonMaskerApiEquivalence(jsonMasker, """
                 {
                   "string": "maskMe",
                   "number": 12345,
@@ -368,8 +358,7 @@ class CustomKeyMaskingConfigTest {
                     "value2": "secret: very much"
                   }
                 }
-                """);
-        Assertions.assertThat(masked).isEqualTo("""
+                """, """
                 {
                   "string": "***",
                   "number": "###",
@@ -381,8 +370,7 @@ class CustomKeyMaskingConfigTest {
                     "value2": "***"
                   }
                 }
-                """
-        );
+                """);
     }
 
     @Test
@@ -417,6 +405,11 @@ class CustomKeyMaskingConfigTest {
                   "customValueMasker": "maskMe"
                 }
                 """);
+        jsonMasker.mask(new ByteArrayInputStream("""
+                {
+                  "customValueMasker": "maskMe"
+                }
+                """.getBytes(StandardCharsets.UTF_8)), new ByteArrayOutputStream());
     }
 
     @Test
@@ -427,44 +420,38 @@ class CustomKeyMaskingConfigTest {
                                 .maskKeys("customValueMasker")
                                 .maskNumbersWith(ValueMaskers.eachDigitWith("*"))
                                 .build());
-        Assertions.assertThat(
-                        jsonMasker.mask(
-                                """
-                                        {
-                                          "customValueMasker": 0
-                                        }
-                                        """))
-                .isEqualTo(
-                        """
-                                {
-                                  "customValueMasker": "*"
-                                }
-                                """);
-        Assertions.assertThat(
-                        jsonMasker.mask(
-                                """
-                                        {
-                                          "customValueMasker": 123
-                                        }
-                                        """))
-                .isEqualTo(
-                        """
-                                {
-                                  "customValueMasker": "***"
-                                }
-                                """);
-        Assertions.assertThat(
-                        jsonMasker.mask(
-                                """
-                                        {
-                                          "customValueMasker": 12345
-                                        }
-                                        """))
-                .isEqualTo(
-                        """
-                                {
-                                  "customValueMasker": "*****"
-                                }
-                                """);
+        JsonMaskerTestUtil.assertJsonMaskerApiEquivalence(jsonMasker,
+                """
+                        {
+                          "customValueMasker": 0
+                        }
+                        """,
+                """
+                        {
+                          "customValueMasker": "*"
+                        }
+                        """);
+        JsonMaskerTestUtil.assertJsonMaskerApiEquivalence(jsonMasker,
+                """
+                        {
+                          "customValueMasker": 123
+                        }
+                        """,
+                """
+                        {
+                          "customValueMasker": "***"
+                        }
+                        """);
+        JsonMaskerTestUtil.assertJsonMaskerApiEquivalence(jsonMasker,
+                """
+                        {
+                          "customValueMasker": 12345
+                        }
+                        """,
+                """
+                        {
+                          "customValueMasker": "*****"
+                        }
+                        """);
     }
 }

--- a/src/test/java/dev/blaauwendraad/masker/json/EmptyKeyTest.java
+++ b/src/test/java/dev/blaauwendraad/masker/json/EmptyKeyTest.java
@@ -6,13 +6,13 @@ import org.junit.jupiter.params.provider.MethodSource;
 import java.io.IOException;
 import java.util.stream.Stream;
 
-import static org.assertj.core.api.Assertions.assertThat;
 
 final class EmptyKeyTest {
     @ParameterizedTest
     @MethodSource("emptyKeyTestFile")
     void emptyKey(JsonMaskerTestInstance testInstance) {
-        assertThat(testInstance.jsonMasker().mask(testInstance.input())).isEqualTo(testInstance.expectedOutput());
+        JsonMaskerTestUtil.assertJsonMaskerApiEquivalence(testInstance.jsonMasker(), testInstance.input(),
+                testInstance.expectedOutput());
     }
 
     private static Stream<JsonMaskerTestInstance> emptyKeyTestFile() throws IOException {

--- a/src/test/java/dev/blaauwendraad/masker/json/EscapedCharactersTest.java
+++ b/src/test/java/dev/blaauwendraad/masker/json/EscapedCharactersTest.java
@@ -6,13 +6,13 @@ import org.junit.jupiter.params.provider.MethodSource;
 import java.io.IOException;
 import java.util.stream.Stream;
 
-import static org.assertj.core.api.Assertions.assertThat;
 
 final class EscapedCharactersTest {
     @ParameterizedTest
     @MethodSource("escapedCharactersFile")
     void escapedCharacters(JsonMaskerTestInstance testInstance) {
-        assertThat(testInstance.jsonMasker().mask(testInstance.input())).isEqualTo(testInstance.expectedOutput());
+        JsonMaskerTestUtil.assertJsonMaskerApiEquivalence(testInstance.jsonMasker(), testInstance.input(),
+                testInstance.expectedOutput());
     }
 
     private static Stream<JsonMaskerTestInstance> escapedCharactersFile() throws IOException {

--- a/src/test/java/dev/blaauwendraad/masker/json/FuzzingTest.java
+++ b/src/test/java/dev/blaauwendraad/masker/json/FuzzingTest.java
@@ -18,7 +18,6 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import static org.assertj.core.api.Assertions.assertThat;
 
 final class FuzzingTest {
     private static final Set<String> DEFAULT_TARGET_KEYS = Set.of("targetKey1", "targetKey2", "targetKey3");
@@ -47,11 +46,7 @@ final class FuzzingTest {
                 String randomJsonString = formatter.format(randomJsonNode);
                 String jacksonMaskingOutput = ParseAndMaskUtil.mask(randomJsonString, jsonMaskingConfig).toString();
                 try {
-                    String keyContainsOutput = masker.mask(randomJsonString);
-                    // parsing again by jackson to get canonical representation
-                    assertThat(ParseAndMaskUtil.DEFAULT_OBJECT_MAPPER.readTree(keyContainsOutput))
-                            .as("Failed for input: " + randomJsonString)
-                            .isEqualTo(ParseAndMaskUtil.DEFAULT_OBJECT_MAPPER.readTree(jacksonMaskingOutput));
+                    JsonMaskerTestUtil.assertJsonMaskerApiEquivalence(masker, randomJsonString, jacksonMaskingOutput, true);
                 } catch (Exception e) {
                     throw new IllegalStateException("Failed for input: " + randomJsonString, e);
                 }

--- a/src/test/java/dev/blaauwendraad/masker/json/InvalidJsonTest.java
+++ b/src/test/java/dev/blaauwendraad/masker/json/InvalidJsonTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -58,7 +59,10 @@ class InvalidJsonTest {
 
     private void maskStreamsWithinTimeLimit(String json) {
         ExecutorService executor = Executors.newSingleThreadExecutor();
-        Future<?> future = executor.submit(() -> jsonMasker.mask(new ByteArrayInputStream(json.getBytes()), new ByteArrayOutputStream()));
+        Future<?> future = executor.submit(() -> jsonMasker.mask(
+                new ByteArrayInputStream(json.getBytes(StandardCharsets.UTF_8)),
+                new ByteArrayOutputStream()
+        ));
         try {
             future.get(50, TimeUnit.MILLISECONDS);
         } catch (ExecutionException e) {

--- a/src/test/java/dev/blaauwendraad/masker/json/InvalidJsonTest.java
+++ b/src/test/java/dev/blaauwendraad/masker/json/InvalidJsonTest.java
@@ -4,6 +4,8 @@ import dev.blaauwendraad.masker.json.config.JsonMaskingConfig;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -21,22 +23,42 @@ class InvalidJsonTest {
 
     @Test
     void arrayWithInvalidCharacterAfterValue() {
-        maskWithinTimeLimit("[\"value\"a]");
+        maskBytesWithinTimeLimit("[\"value\"a]");
+        maskStreamsWithinTimeLimit("[\"value\"a]");
     }
 
     @Test
     void objectWithInvalidCharacterAfterKey() {
-        maskWithinTimeLimit("{\"key\":\"value\"a}}}}");
+        maskBytesWithinTimeLimit("{\"key\":\"value\"a}}}}");
+        maskStreamsWithinTimeLimit("{\"key\":\"value\"a}}}}");
     }
 
     @Test
     void notFinishedString() {
-        maskWithinTimeLimit("\"a");
+        maskBytesWithinTimeLimit("\"a");
+        maskStreamsWithinTimeLimit("\"a");
     }
 
-    private void maskWithinTimeLimit(String json) {
+    private void maskBytesWithinTimeLimit(String json) {
         ExecutorService executor = Executors.newSingleThreadExecutor();
         Future<?> future = executor.submit(() -> jsonMasker.mask(json));
+        try {
+            future.get(50, TimeUnit.MILLISECONDS);
+        } catch (ExecutionException e) {
+            // execution failed with an exception, that's acceptable
+            Assertions.assertThat(e.getCause())
+                    .isInstanceOfAny(InvalidJsonException.class);
+        } catch (InterruptedException | TimeoutException e) {
+            Assertions.fail("Masking of %s hasn't completed within 50ms.".formatted(json));
+        } finally {
+            future.cancel(true);
+            executor.shutdownNow();
+        }
+    }
+
+    private void maskStreamsWithinTimeLimit(String json) {
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+        Future<?> future = executor.submit(() -> jsonMasker.mask(new ByteArrayInputStream(json.getBytes()), new ByteArrayOutputStream()));
         try {
             future.get(50, TimeUnit.MILLISECONDS);
         } catch (ExecutionException e) {

--- a/src/test/java/dev/blaauwendraad/masker/json/JSONTestSuiteTest.java
+++ b/src/test/java/dev/blaauwendraad/masker/json/JSONTestSuiteTest.java
@@ -8,7 +8,11 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
 import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -83,6 +87,7 @@ public class JSONTestSuiteTest {
         );
 
         byte[] actual = jsonMasker.mask(file.originalContent);
+        JsonMaskerTestUtil.assertJsonMaskerApiEquivalence(jsonMasker, new String(file.originalContent, StandardCharsets.UTF_8));
 
         // must be equivalent to being parsed by jackson
         try {
@@ -108,6 +113,7 @@ public class JSONTestSuiteTest {
         );
 
         byte[] actual = jsonMasker.mask(file.originalContent);
+        JsonMaskerTestUtil.assertJsonMaskerApiEquivalence(jsonMasker, new String(file.originalContent, StandardCharsets.UTF_8));
 
         if (INVALID_JSON_JACKSON_DIFFERENT_BEHAVIOR.contains(file.name)) {
             // for these jackson behavior is different from java.lang.String parsing of UTF-8 characters
@@ -141,6 +147,10 @@ public class JSONTestSuiteTest {
         );
 
         if (PRODUCING_STACK_OVER_FLOW.contains(file.name)) {
+            InputStream inputStream = new ByteArrayInputStream(file.originalContent);
+            OutputStream outputStream = new ByteArrayOutputStream();
+            Assertions.assertThatThrownBy(() -> jsonMasker.mask(inputStream, outputStream))
+                    .isInstanceOf(InvalidJsonException.class);
             Assertions.assertThatThrownBy(() -> jsonMasker.mask(file.originalContent))
                     .isInstanceOf(InvalidJsonException.class);
         } else {
@@ -159,6 +169,7 @@ public class JSONTestSuiteTest {
         );
 
         byte[] actual = jsonMasker.mask(file.originalContent);
+        JsonMaskerTestUtil.assertJsonMaskerApiEquivalence(jsonMasker, new String(file.originalContent, StandardCharsets.UTF_8));
 
         Assertions.assertThat(file.maskedContent).isNotNull();
         Assertions.assertThat(new String(actual, StandardCharsets.UTF_8))
@@ -179,6 +190,10 @@ public class JSONTestSuiteTest {
         );
 
         if (INVALID_UTF_8.contains(file.name)) {
+            InputStream inputStream = new ByteArrayInputStream(file.originalContent);
+            OutputStream outputStream = new ByteArrayOutputStream();
+            Assertions.assertThatThrownBy(() -> jsonMasker.mask(inputStream, outputStream))
+                    .isInstanceOf(InvalidJsonException.class);
             Assertions.assertThatThrownBy(() -> jsonMasker.mask(file.originalContent))
                     .isInstanceOf(InvalidJsonException.class);
         } else {

--- a/src/test/java/dev/blaauwendraad/masker/json/JsonMaskerTestUtil.java
+++ b/src/test/java/dev/blaauwendraad/masker/json/JsonMaskerTestUtil.java
@@ -1,12 +1,19 @@
 package dev.blaauwendraad.masker.json;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import dev.blaauwendraad.masker.json.config.JsonMaskingConfig;
+import dev.blaauwendraad.masker.json.config.JsonMaskingConfigTestUtil;
 import dev.blaauwendraad.masker.json.config.KeyMaskingConfig;
+import org.jspecify.annotations.Nullable;
+import org.junit.jupiter.api.Assertions;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
@@ -15,6 +22,8 @@ import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
 public final class JsonMaskerTestUtil {
+    private static final int MINIMAL_STREAMING_BUFFER_SIZE = 5;
+
     private JsonMaskerTestUtil() {
     }
 
@@ -114,5 +123,52 @@ public final class JsonMaskerTestUtil {
 
     private static <T> Set<T> asSet(JsonNode value, Function<JsonNode, T> mapper) {
         return StreamSupport.stream(value.spliterator(), false).map(mapper).collect(Collectors.toSet());
+    }
+
+    /**
+     * Asserts that JsonMasker result matches the expected output and is the same when using bytes mode,
+     * streaming mode and streaming mode with minimal buffer size.
+     *
+     * @param jsonMasker an instance of JsonMasker
+     * @param input the input JSON
+     */
+    public static void assertJsonMaskerApiEquivalence(JsonMasker jsonMasker,
+                                                      String input,
+                                                      @Nullable String expectedOutput,
+                                                      boolean pretty) {
+        String bytesOutput = jsonMasker.mask(input);
+        String streamsOutput = getStreamingModeOutput(jsonMasker, input);
+        int oldBufferSize = ((KeyContainsMasker) jsonMasker).maskingConfig.bufferSize();
+        JsonMaskingConfigTestUtil.setBufferSize(((KeyContainsMasker) jsonMasker).maskingConfig, MINIMAL_STREAMING_BUFFER_SIZE);
+        String minimalBufferStreamsOutput = getStreamingModeOutput(jsonMasker, input);
+        JsonMaskingConfigTestUtil.setBufferSize(((KeyContainsMasker) jsonMasker).maskingConfig, oldBufferSize);
+        if (pretty) {
+            try {
+                bytesOutput = ParseAndMaskUtil.DEFAULT_OBJECT_MAPPER.readTree(bytesOutput).toString();
+                streamsOutput = ParseAndMaskUtil.DEFAULT_OBJECT_MAPPER.readTree(streamsOutput).toString();
+                minimalBufferStreamsOutput = ParseAndMaskUtil.DEFAULT_OBJECT_MAPPER.readTree(minimalBufferStreamsOutput).toString();
+            } catch (JsonProcessingException e) {
+                throw new IllegalStateException("Failed for input: " + input, e);
+            }
+        }
+        if (expectedOutput != null) {
+            Assertions.assertEquals(expectedOutput, bytesOutput, "Failed for input: " + input);
+        }
+        Assertions.assertEquals(bytesOutput, streamsOutput, "Streaming failed for input: " + input);
+        Assertions.assertEquals(streamsOutput, minimalBufferStreamsOutput, "Minimal buffer streaming failed for input: " + input);
+    }
+
+    public static void assertJsonMaskerApiEquivalence(JsonMasker jsonMasker, String input) {
+        assertJsonMaskerApiEquivalence(jsonMasker, input, null, false);
+    }
+
+    public static void assertJsonMaskerApiEquivalence(JsonMasker jsonMasker, String input, String expectedOutput) {
+        assertJsonMaskerApiEquivalence(jsonMasker, input, expectedOutput, false);
+    }
+
+    private static String getStreamingModeOutput(JsonMasker jsonMasker, String input) {
+        ByteArrayOutputStream streamsOutput = new ByteArrayOutputStream();
+        Assertions.assertDoesNotThrow(() -> jsonMasker.mask(new ByteArrayInputStream(input.getBytes(StandardCharsets.UTF_8)), streamsOutput));
+        return streamsOutput.toString(StandardCharsets.UTF_8);
     }
 }

--- a/src/test/java/dev/blaauwendraad/masker/json/JsonPathLookupTest.java
+++ b/src/test/java/dev/blaauwendraad/masker/json/JsonPathLookupTest.java
@@ -6,13 +6,13 @@ import org.junit.jupiter.params.provider.MethodSource;
 import java.io.IOException;
 import java.util.stream.Stream;
 
-import static org.assertj.core.api.Assertions.assertThat;
 
 class JsonPathLookupTest {
     @ParameterizedTest
     @MethodSource("jsonPathFile")
     void lookupTestJsonPaths(JsonMaskerTestInstance testInstance) {
-        assertThat(testInstance.jsonMasker().mask(testInstance.input())).isEqualTo(testInstance.expectedOutput());
+        JsonMaskerTestUtil.assertJsonMaskerApiEquivalence(testInstance.jsonMasker(), testInstance.input(),
+                testInstance.expectedOutput());
     }
 
     private static Stream<JsonMaskerTestInstance> jsonPathFile() throws IOException {

--- a/src/test/java/dev/blaauwendraad/masker/json/LargeStreamTest.java
+++ b/src/test/java/dev/blaauwendraad/masker/json/LargeStreamTest.java
@@ -3,7 +3,6 @@ package dev.blaauwendraad.masker.json;
 import dev.blaauwendraad.masker.json.config.JsonMaskingConfig;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -18,7 +17,6 @@ import java.nio.file.Path;
  * Tests that the masker is able to process streams of any size in buffering mode.
  * The test creates ~1GB input file and the expected result file. Then it runs the masker in buffering mode and checks
  * that the actual result matches the expected result.
- * Keeping this test disabled because I am not sure if running it on CI is a good idea
  */
 final class LargeStreamTest {
     Path inputFilePath;
@@ -39,7 +37,6 @@ final class LargeStreamTest {
     }
 
     @Test
-    @Disabled("Run it manually")
     void shouldProcessLargeJson() throws IOException {
         // process the input file and write the result into actual_result.json file
         try (InputStream inputStream = Files.newInputStream(inputFilePath);

--- a/src/test/java/dev/blaauwendraad/masker/json/LargeStreamTest.java
+++ b/src/test/java/dev/blaauwendraad/masker/json/LargeStreamTest.java
@@ -1,0 +1,66 @@
+package dev.blaauwendraad.masker.json;
+
+import dev.blaauwendraad.masker.json.config.JsonMaskingConfig;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+/**
+ * Tests that the masker is able to process streams of any size in buffering mode.
+ * The test creates ~1GB input file and the expected result file. Then it runs the masker in buffering mode and checks
+ * that the actual result matches the expected result.
+ * Keeping this test disabled because I am not sure if running it on CI is a good idea
+ */
+final class LargeStreamTest {
+    Path inputFilePath;
+    Path expectedResultFilePath;
+    Path actualResultFilePath;
+
+    @BeforeEach
+    void setupFiles(@TempDir Path tempDir) throws IOException {
+        inputFilePath = tempDir.resolve("input.json");
+        expectedResultFilePath = tempDir.resolve("expected_result.json");
+        actualResultFilePath = tempDir.resolve("actual_result.json");
+        for (int i = 0; i < 65536; i++) {
+            Files.writeString(inputFilePath, "{\"key\":\"mask\"},".repeat(1024));
+            Files.writeString(expectedResultFilePath, "{\"key\":\"***\"},".repeat(1024));
+        }
+        Files.writeString(inputFilePath, "{\"key\":\"mask\"}");
+        Files.writeString(expectedResultFilePath, "{\"key\":\"***\"}");
+    }
+
+    @Test
+    @Disabled("Run it manually")
+    void shouldProcessLargeJson() throws IOException {
+        // process the input file and write the result into actual_result.json file
+        try (InputStream inputStream = Files.newInputStream(inputFilePath);
+             OutputStream outputStream = Files.newOutputStream(actualResultFilePath)) {
+            JsonMasker jsonMasker = JsonMasker.getMasker(JsonMaskingConfig.builder().allowKeys().build());
+            jsonMasker.mask(inputStream, outputStream);
+        }
+
+        // assert correctness of the result
+        try (InputStream expectedResultFile = Files.newInputStream(expectedResultFilePath);
+             InputStream actualResultFile = Files.newInputStream(actualResultFilePath)) {
+            String expected = new String(expectedResultFile.readNBytes(512), StandardCharsets.UTF_8);
+            String actual = new String(actualResultFile.readNBytes(512), StandardCharsets.UTF_8);
+            while (!expected.isEmpty() || !actual.isEmpty()) {
+                Assertions.assertEquals(expected, actual);
+                expected = new String(expectedResultFile.readNBytes(512), StandardCharsets.UTF_8);
+                actual = new String(actualResultFile.readNBytes(512), StandardCharsets.UTF_8);
+            }
+            Assertions.assertEquals(0, expectedResultFile.available());
+            Assertions.assertEquals(0, actualResultFile.available());
+        }
+    }
+
+}

--- a/src/test/java/dev/blaauwendraad/masker/json/MaskAllKeysTest.java
+++ b/src/test/java/dev/blaauwendraad/masker/json/MaskAllKeysTest.java
@@ -10,13 +10,13 @@ import java.io.IOException;
 import java.util.Set;
 import java.util.stream.Stream;
 
-import static org.assertj.core.api.Assertions.assertThat;
 
 final class MaskAllKeysTest {
     @ParameterizedTest
     @MethodSource("testMaskAllKeys")
     void maskAllKeysFromFile(JsonMaskerTestInstance testInstance) {
-        assertThat(testInstance.jsonMasker().mask(testInstance.input())).isEqualTo(testInstance.expectedOutput());
+        JsonMaskerTestUtil.assertJsonMaskerApiEquivalence(testInstance.jsonMasker(), testInstance.input(),
+                testInstance.expectedOutput());
     }
 
     private static Stream<JsonMaskerTestInstance> testMaskAllKeys() throws IOException {

--- a/src/test/java/dev/blaauwendraad/masker/json/MaskArrayValuesTest.java
+++ b/src/test/java/dev/blaauwendraad/masker/json/MaskArrayValuesTest.java
@@ -6,13 +6,13 @@ import org.junit.jupiter.params.provider.MethodSource;
 import java.io.IOException;
 import java.util.stream.Stream;
 
-import static org.assertj.core.api.Assertions.assertThat;
 
 final class MaskArrayValuesTest {
     @ParameterizedTest
     @MethodSource("arrayValuesFile")
     void arrayValues(JsonMaskerTestInstance testInstance) {
-        assertThat(testInstance.jsonMasker().mask(testInstance.input())).isEqualTo(testInstance.expectedOutput());
+        JsonMaskerTestUtil.assertJsonMaskerApiEquivalence(testInstance.jsonMasker(), testInstance.input(),
+                testInstance.expectedOutput());
     }
 
     private static Stream<JsonMaskerTestInstance> arrayValuesFile() throws IOException {

--- a/src/test/java/dev/blaauwendraad/masker/json/MaskObjectInNonMaskedArrayTest.java
+++ b/src/test/java/dev/blaauwendraad/masker/json/MaskObjectInNonMaskedArrayTest.java
@@ -6,13 +6,13 @@ import org.junit.jupiter.params.provider.MethodSource;
 import java.io.IOException;
 import java.util.stream.Stream;
 
-import static org.assertj.core.api.Assertions.assertThat;
 
 final class MaskObjectInNonMaskedArrayTest {
     @ParameterizedTest
     @MethodSource("objectInNonMaskedArrayValues")
     void maskObjectInNonMaskedArray(JsonMaskerTestInstance testInstance) {
-        assertThat(testInstance.jsonMasker().mask(testInstance.input())).isEqualTo(testInstance.expectedOutput());
+        JsonMaskerTestUtil.assertJsonMaskerApiEquivalence(testInstance.jsonMasker(), testInstance.input(),
+                testInstance.expectedOutput());
     }
 
     private static Stream<JsonMaskerTestInstance> objectInNonMaskedArrayValues() throws IOException {

--- a/src/test/java/dev/blaauwendraad/masker/json/MaskObjectValuesTest.java
+++ b/src/test/java/dev/blaauwendraad/masker/json/MaskObjectValuesTest.java
@@ -6,13 +6,13 @@ import org.junit.jupiter.params.provider.MethodSource;
 import java.io.IOException;
 import java.util.stream.Stream;
 
-import static org.assertj.core.api.Assertions.assertThat;
 
-public class MaskObjectValuesTest {
+class MaskObjectValuesTest {
     @ParameterizedTest
     @MethodSource("nestedObjectFile")
     void multiTargetKey(JsonMaskerTestInstance testInstance) {
-        assertThat(testInstance.jsonMasker().mask(testInstance.input())).isEqualTo(testInstance.expectedOutput());
+        JsonMaskerTestUtil.assertJsonMaskerApiEquivalence(testInstance.jsonMasker(), testInstance.input(),
+                testInstance.expectedOutput());
     }
 
     private static Stream<JsonMaskerTestInstance> nestedObjectFile() throws IOException {

--- a/src/test/java/dev/blaauwendraad/masker/json/MaskingStateTest.java
+++ b/src/test/java/dev/blaauwendraad/masker/json/MaskingStateTest.java
@@ -39,7 +39,7 @@ class MaskingStateTest {
         Assertions.assertThat(maskingState).hasToString("""
                  value"
                 }
-                ><end of json>
+                ><end of buffer>
                 """.stripTrailing());
     }
 
@@ -66,7 +66,7 @@ class MaskingStateTest {
                 }
                 """.getBytes(StandardCharsets.UTF_8), false);
 
-        Assertions.assertThatThrownBy(() -> maskingState.getCurrentValueStartIndex())
+        Assertions.assertThatThrownBy(maskingState::getCurrentTokenStartIndex)
                 .isInstanceOf(IllegalStateException.class);
     }
 
@@ -90,4 +90,5 @@ class MaskingStateTest {
                 .isInstanceOf(InvalidJsonException.class)
                 .hasMessage("Didn't like the value at index 3 at index 19");
     }
+
 }

--- a/src/test/java/dev/blaauwendraad/masker/json/MultiJsonTest.java
+++ b/src/test/java/dev/blaauwendraad/masker/json/MultiJsonTest.java
@@ -1,7 +1,6 @@
 package dev.blaauwendraad.masker.json;
 
 import dev.blaauwendraad.masker.json.config.JsonMaskingConfig;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.util.Set;
@@ -12,70 +11,71 @@ public class MultiJsonTest {
     void shouldMaskJsonLinesObjects() {
         JsonMasker jsonMasker = JsonMasker.getMasker(Set.of("maskMe"));
 
-        Assertions.assertThat(jsonMasker.mask(
+        JsonMaskerTestUtil.assertJsonMaskerApiEquivalence(jsonMasker,
+                """
+                        {"maskMe":"secret"}
+                        {"maskMe":"secret"}
+                        {"maskMe":"secret"}
+                        """,
+                """
+                        {"maskMe":"***"}
+                        {"maskMe":"***"}
+                        {"maskMe":"***"}
                         """
-                                {"maskMe":"secret"}
-                                {"maskMe":"secret"}
-                                {"maskMe":"secret"}
-                                """))
-                .isEqualTo(
-                        """
-                                {"maskMe":"***"}
-                                {"maskMe":"***"}
-                                {"maskMe":"***"}
-                                """);
+        );
     }
 
     @Test
     void shouldMaskJsonLinesArrays() {
         JsonMasker jsonMasker = JsonMasker.getMasker(Set.of("maskMe"));
 
-        Assertions.assertThat(jsonMasker.mask(
+        JsonMaskerTestUtil.assertJsonMaskerApiEquivalence(jsonMasker,
+                """
+                        [{"maskMe":"secret"}]
+                        [{"maskMe":"secret"}]
+                        [{"maskMe":"secret"}]
+                        """,
+                """
+                        [{"maskMe":"***"}]
+                        [{"maskMe":"***"}]
+                        [{"maskMe":"***"}]
                         """
-                                [{"maskMe":"secret"}]
-                                [{"maskMe":"secret"}]
-                                [{"maskMe":"secret"}]
-                                """))
-                .isEqualTo(
-                        """
-                                [{"maskMe":"***"}]
-                                [{"maskMe":"***"}]
-                                [{"maskMe":"***"}]
-                                """);
+        );
     }
 
     @Test
     void shouldMaskJsonLinesMixedTypes() {
         JsonMasker jsonMasker = JsonMasker.getMasker(JsonMaskingConfig.builder().allowKeys().build());
 
-        Assertions.assertThat(jsonMasker.mask(
+        JsonMaskerTestUtil.assertJsonMaskerApiEquivalence(jsonMasker,
+                """
+                        "secret"
+                        true
+                        false
+                        null
+                        123
+                        """,
+                """
+                        "***"
+                        "&&&"
+                        "&&&"
+                        null
+                        "###"
                         """
-                                "secret"
-                                true
-                                false
-                                null
-                                123
-                                """))
-                .isEqualTo(
-                        """
-                                "***"
-                                "&&&"
-                                "&&&"
-                                null
-                                "###"
-                                """);
+        );
     }
+
     @Test
     void shouldMaskRepeatedJsonsWithoutNewLines() {
         JsonMasker jsonMasker = JsonMasker.getMasker(Set.of("maskMe"));
 
-        Assertions.assertThat(jsonMasker.mask(
+        JsonMaskerTestUtil.assertJsonMaskerApiEquivalence(jsonMasker,
+                """
+                        {"maskMe":"secret"}{"maskMe":"secret"}   {"maskMe":"secret"}
+                        """,
+                """
+                        {"maskMe":"***"}{"maskMe":"***"}   {"maskMe":"***"}
                         """
-                                {"maskMe":"secret"}{"maskMe":"secret"}   {"maskMe":"secret"}
-                                """))
-                .isEqualTo(
-                        """
-                                {"maskMe":"***"}{"maskMe":"***"}   {"maskMe":"***"}
-                                """);
+        );
     }
 }

--- a/src/test/java/dev/blaauwendraad/masker/json/MultiTargetKeyTest.java
+++ b/src/test/java/dev/blaauwendraad/masker/json/MultiTargetKeyTest.java
@@ -6,13 +6,13 @@ import org.junit.jupiter.params.provider.MethodSource;
 import java.io.IOException;
 import java.util.stream.Stream;
 
-import static org.assertj.core.api.Assertions.assertThat;
 
 final class MultiTargetKeyTest {
     @ParameterizedTest
     @MethodSource("multiTargetKeyFile")
     void multiTargetKey(JsonMaskerTestInstance testInstance) {
-        assertThat(testInstance.jsonMasker().mask(testInstance.input())).isEqualTo(testInstance.expectedOutput());
+        JsonMaskerTestUtil.assertJsonMaskerApiEquivalence(testInstance.jsonMasker(), testInstance.input(),
+                testInstance.expectedOutput());
     }
 
     private static Stream<JsonMaskerTestInstance> multiTargetKeyFile() throws IOException {

--- a/src/test/java/dev/blaauwendraad/masker/json/NoFailingExecutionFuzzingTest.java
+++ b/src/test/java/dev/blaauwendraad/masker/json/NoFailingExecutionFuzzingTest.java
@@ -11,6 +11,9 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Set;
@@ -99,6 +102,13 @@ final class NoFailingExecutionFuzzingTest {
                         () -> keyContainsMasker.mask(mutatedJsonNodeString),
                         String.format(
                                 "Failed for the following JSON:\n%s",
+                                mutatedJsonNodeString));
+                Assertions.assertDoesNotThrow(
+                        () -> keyContainsMasker.mask(
+                                new ByteArrayInputStream(mutatedJsonNodeString.getBytes(StandardCharsets.UTF_8)),
+                                new ByteArrayOutputStream()),
+                        String.format(
+                                "Streaming mode failed for the following JSON:\n%s",
                                 mutatedJsonNodeString));
             } else {
                 try {

--- a/src/test/java/dev/blaauwendraad/masker/json/NotPrettyJsonTest.java
+++ b/src/test/java/dev/blaauwendraad/masker/json/NotPrettyJsonTest.java
@@ -6,14 +6,14 @@ import org.junit.jupiter.params.provider.MethodSource;
 import java.util.Set;
 import java.util.stream.Stream;
 
-import static org.assertj.core.api.Assertions.assertThat;
 
 class NotPrettyJsonTest {
 
     @ParameterizedTest
     @MethodSource("notPrettyJson")
     void notPrettyJsonTest(JsonMaskerTestInstance testInstance) {
-        assertThat(testInstance.jsonMasker().mask(testInstance.input())).isEqualTo(testInstance.expectedOutput());
+        JsonMaskerTestUtil.assertJsonMaskerApiEquivalence(testInstance.jsonMasker(), testInstance.input(),
+                testInstance.expectedOutput());
     }
 
     private static Stream<JsonMaskerTestInstance> notPrettyJson() {

--- a/src/test/java/dev/blaauwendraad/masker/json/NumberMaskingTest.java
+++ b/src/test/java/dev/blaauwendraad/masker/json/NumberMaskingTest.java
@@ -6,13 +6,13 @@ import org.junit.jupiter.params.provider.MethodSource;
 import java.io.IOException;
 import java.util.stream.Stream;
 
-import static org.assertj.core.api.Assertions.assertThat;
 
 class NumberMaskingTest {
     @ParameterizedTest
     @MethodSource("numberMaskingFile")
     void numberMasking(JsonMaskerTestInstance testInstance) {
-        assertThat(testInstance.jsonMasker().mask(testInstance.input())).isEqualTo(testInstance.expectedOutput());
+        JsonMaskerTestUtil.assertJsonMaskerApiEquivalence(testInstance.jsonMasker(), testInstance.input(),
+                testInstance.expectedOutput());
     }
 
     private static Stream<JsonMaskerTestInstance> numberMaskingFile() throws IOException {

--- a/src/test/java/dev/blaauwendraad/masker/json/PreserveLengthTest.java
+++ b/src/test/java/dev/blaauwendraad/masker/json/PreserveLengthTest.java
@@ -6,13 +6,13 @@ import org.junit.jupiter.params.provider.MethodSource;
 import java.io.IOException;
 import java.util.stream.Stream;
 
-import static org.assertj.core.api.Assertions.assertThat;
 
 final class PreserveLengthTest {
     @ParameterizedTest
     @MethodSource("lengthObfuscationFile")
     void lengthObfuscation(JsonMaskerTestInstance testInstance) {
-        assertThat(testInstance.jsonMasker().mask(testInstance.input())).isEqualTo(testInstance.expectedOutput());
+        JsonMaskerTestUtil.assertJsonMaskerApiEquivalence(testInstance.jsonMasker(),
+                testInstance.input(), testInstance.expectedOutput());
     }
 
     private static Stream<JsonMaskerTestInstance> lengthObfuscationFile() throws IOException {

--- a/src/test/java/dev/blaauwendraad/masker/json/RecurringKeyTest.java
+++ b/src/test/java/dev/blaauwendraad/masker/json/RecurringKeyTest.java
@@ -6,13 +6,13 @@ import org.junit.jupiter.params.provider.MethodSource;
 import java.io.IOException;
 import java.util.stream.Stream;
 
-import static org.assertj.core.api.Assertions.assertThat;
 
 class RecurringKeyTest {
     @ParameterizedTest
     @MethodSource("recurringKeyFile")
     void recurringKey(JsonMaskerTestInstance testInstance) {
-        assertThat(testInstance.jsonMasker().mask(testInstance.input())).isEqualTo(testInstance.expectedOutput());
+        JsonMaskerTestUtil.assertJsonMaskerApiEquivalence(testInstance.jsonMasker(), testInstance.input(),
+                testInstance.expectedOutput());
     }
 
     private static Stream<JsonMaskerTestInstance> recurringKeyFile() throws IOException {

--- a/src/test/java/dev/blaauwendraad/masker/json/StreamingModeTest.java
+++ b/src/test/java/dev/blaauwendraad/masker/json/StreamingModeTest.java
@@ -1,0 +1,158 @@
+package dev.blaauwendraad.masker.json;
+
+import dev.blaauwendraad.masker.json.config.JsonMaskingConfig;
+import dev.blaauwendraad.masker.json.config.JsonMaskingConfigTestUtil;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Set;
+import java.util.stream.Stream;
+
+/**
+ * The test suite covers different circumstances under which the streaming buffer ends
+ */
+class StreamingModeTest {
+
+    @ParameterizedTest
+    @MethodSource("getBufferingSituations")
+    void shouldHandleBufferingSuccessfully(Integer initialBufferSize,
+                                           Set<String> maskKeys,
+                                           String json,
+                                           String expectedResult) {
+        JsonMaskingConfig config = JsonMaskingConfig.builder().maskKeys(maskKeys).build();
+        JsonMaskingConfigTestUtil.setBufferSize(JsonMaskingConfig.builder().maskKeys(maskKeys).build(), initialBufferSize);
+        JsonMasker jsonMasker = JsonMasker.getMasker(config);
+
+        ByteArrayInputStream inputStream = new ByteArrayInputStream(json.getBytes(StandardCharsets.UTF_8));
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        jsonMasker.mask(inputStream, outputStream);
+
+        Assertions.assertThat(outputStream).hasToString(expectedResult);
+    }
+
+    @Test
+    void shouldAbortExecutionOnTooLongToken() {
+        JsonMaskingConfig config = JsonMaskingConfig.builder().maskKeys("mask").build();
+        JsonMasker jsonMasker = JsonMasker.getMasker(config);
+        String json = "{\"mask\":%s}".formatted("a".repeat(100_000));
+
+
+        Assertions.assertThatThrownBy(() -> jsonMasker.mask(
+                new ByteArrayInputStream(json.getBytes(StandardCharsets.UTF_8)),
+                new ByteArrayOutputStream())
+        ).isInstanceOf(IllegalStateException.class);
+    }
+
+    private static Stream<Arguments> getBufferingSituations() {
+        return Stream.of(
+                // process json with a single buffer.
+                Arguments.of(
+                        1024,
+                        Set.of("mask"),
+                        "{\"mask\":\"value\"}",
+                        "{\"mask\":\"***\"}"
+                ),
+                // process json with re-reading the buffer, no token start index is registered in between.
+                // the buffer ends at the middle of not registered token ('0' in ': [0]')
+                Arguments.of(
+                        16,
+                        Set.of("mask"),
+                        "{\"doNotMask\": [0], \"mask\": \"a\"}",
+                        "{\"doNotMask\": [0], \"mask\": \"***\"}"
+                ),
+                // process json with re-reading the buffer, no token start index is registered in between.
+                // the buffer ends at comma (',' in '[0], ')
+                Arguments.of(
+                        18,
+                        Set.of("mask"),
+                        "{\"doNotMask\": [0], \"mask\": \"a\"}",
+                        "{\"doNotMask\": [0], \"mask\": \"***\"}"
+                ),
+                // process json with re-reading the buffer, no token start index is registered in between.
+                // the buffer ends at the opening of the array ('[' in ': [0]')
+                Arguments.of(
+                        17,
+                        Set.of("mask"),
+                        "{\"doNotMaskMe\": [0], \"mask\": \"a\"}",
+                        "{\"doNotMaskMe\": [0], \"mask\": \"***\"}"
+                ),
+                // process json with re-reading the buffer, no token start index is registered in between.
+                // the buffer ends at the opening of the nested object ('{' in ': {"doNot"')
+                Arguments.of(
+                        17,
+                        Set.of("mask"),
+                        "{\"doNotMaskMe\": {\"doNot\":\"ok\"}, \"mask\": \"a\"}",
+                        "{\"doNotMaskMe\": {\"doNot\":\"ok\"}, \"mask\": \"***\"}"
+                ),
+                // process json with re-reading the buffer, no token start index is registered in between.
+                // the buffer ends at the key/value separator (':' in ': [0]')
+                Arguments.of(
+                        13,
+                        Set.of("mask"),
+                        "{\"doNotMask\": [0], \"mask\": \"a\"}",
+                        "{\"doNotMask\": [0], \"mask\": \"***\"}"
+                ),
+                // process json with re-reading the buffer, token start index is registered for a value.
+                // the buffer ends in registered "value" value
+                Arguments.of(
+                        34,
+                        Set.of("mask"),
+                        "{\"doNotMask\": \"value\", \"mask\": \"value\"}",
+                        "{\"doNotMask\": \"value\", \"mask\": \"***\"}"
+                ),
+                // process json with re-reading the buffer, token start index is registered for a key.
+                // the buffer ends in registered "mask" key
+                Arguments.of(
+                        26,
+                        Set.of("mask"),
+                        "{\"doNotMask\": \"value\", \"mask\": \"value\"}",
+                        "{\"doNotMask\": \"value\", \"mask\": \"***\"}"
+                ),
+                // process json with re-reading the buffer, token start index is registered for a value.
+                // the buffer ends in registered "veryLongValue" value. The value length is equal to a threshold (quarter size of the buffer)
+                Arguments.of(
+                        12,
+                        Set.of("mask"),
+                        "{\"mask\": \"veryLongValue\", \"doNotMask\": \"value\"}",
+                        "{\"mask\": \"***\", \"doNotMask\": \"value\"}"
+                ),
+                // process json with re-reading the buffer, token start index is registered for a value.
+                // the buffer ends in registered "veryLongValue" value. The registered value length is larger than a threshold (quarter size of the buffer)
+                Arguments.of(
+                        12,
+                        Set.of("mask"),
+                        "{\"mask\":\"veryLongValue\", \"doNotMask\": \"value\"}",
+                        "{\"mask\":\"***\", \"doNotMask\": \"value\"}"
+                ),
+                // process json with re-reading the buffer, token start index is registered for a value.
+                // the buffer ends in a registered value whose length is far larger than the initial buffer size
+                Arguments.of(
+                        12,
+                        Set.of("mask"),
+                        "{\"mask\": \"veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongValue\", \"doNotMask\": \"value\"}",
+                        "{\"mask\": \"***\", \"doNotMask\": \"value\"}"
+                ),
+                // process json with re-reading the buffer, token start index is registered for a key.
+                // the buffer ends in a registered key whose length is far larger than the initial buffer size
+                Arguments.of(
+                        12,
+                        Set.of("maskThisVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongKey"),
+                        "{\"doNotMask\": \"value\", \"maskThisVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongKey\": \"value\"}",
+                        "{\"doNotMask\": \"value\", \"maskThisVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongKey\": \"***\"}"
+                ),
+                // process json with registered key and value far larger than the buffer size
+                Arguments.of(
+                        12,
+                        Set.of("maskThisVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongKey"),
+                        "{\"doNotMask\": \"value\", \"maskThisVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongKey\": \"veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongValue\"}",
+                        "{\"doNotMask\": \"value\", \"maskThisVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongKey\": \"***\"}"
+                )
+        );
+    }
+}

--- a/src/test/java/dev/blaauwendraad/masker/json/TargetKeyCaseSensitivityTest.java
+++ b/src/test/java/dev/blaauwendraad/masker/json/TargetKeyCaseSensitivityTest.java
@@ -6,13 +6,13 @@ import org.junit.jupiter.params.provider.MethodSource;
 import java.io.IOException;
 import java.util.stream.Stream;
 
-import static org.assertj.core.api.Assertions.assertThat;
 
 final class TargetKeyCaseSensitivityTest {
     @ParameterizedTest
     @MethodSource("caseSensitivityFile")
     void caseSensitivityInTargetKeys(JsonMaskerTestInstance testInstance) {
-        assertThat(testInstance.jsonMasker().mask(testInstance.input())).isEqualTo(testInstance.expectedOutput());
+        JsonMaskerTestUtil.assertJsonMaskerApiEquivalence(testInstance.jsonMasker(), testInstance.input(),
+                testInstance.expectedOutput());
     }
 
     private static Stream<JsonMaskerTestInstance> caseSensitivityFile() throws IOException {

--- a/src/test/java/dev/blaauwendraad/masker/json/UnicodeCharacterTest.java
+++ b/src/test/java/dev/blaauwendraad/masker/json/UnicodeCharacterTest.java
@@ -6,14 +6,14 @@ import org.junit.jupiter.params.provider.MethodSource;
 import java.util.Set;
 import java.util.stream.Stream;
 
-import static org.assertj.core.api.Assertions.assertThat;
 
 class UnicodeCharacterTest {
 
     @ParameterizedTest
     @MethodSource("unicodeCharacters")
     void unicodeCharacter(JsonMaskerTestInstance testInstance) {
-        assertThat(testInstance.jsonMasker().mask(testInstance.input())).isEqualTo(testInstance.expectedOutput());
+        JsonMaskerTestUtil.assertJsonMaskerApiEquivalence(testInstance.jsonMasker(), testInstance.input(),
+                testInstance.expectedOutput());
     }
 
     private static Stream<JsonMaskerTestInstance> unicodeCharacters() {

--- a/src/test/java/dev/blaauwendraad/masker/json/config/JsonMaskingConfigTestUtil.java
+++ b/src/test/java/dev/blaauwendraad/masker/json/config/JsonMaskingConfigTestUtil.java
@@ -1,0 +1,10 @@
+package dev.blaauwendraad.masker.json.config;
+
+/**
+ * Utility class to configure internal configuration of JsonMaskingConfig
+ */
+public final class JsonMaskingConfigTestUtil {
+    public static void setBufferSize(JsonMaskingConfig jsonMaskingConfig, int bufferSize) {
+        jsonMaskingConfig.bufferSize = bufferSize;
+    }
+}


### PR DESCRIPTION
The PR adds support for Input/Output streams.  

~~The implementation has a new type of MaksingState called "BufferedMaskingState". BufferedMaskingState is a wrapper around MaskingState, which got renamed to "ByteArrayMaskingState" as MaskingState now is an interface.~~ 
The impementation enhances MaskingState to support buffering data from input stream and flushing replacement operations into the output stream. Both streamind mode and byte array mode share the same execution path.

BufferedMaskingState reads chunks of size 8192 bytes from the provided input stream and buffers the data in ByteArrayMaskingState. In case the end of the current buffer is reached while the masker processes a JSON value, the current buffer gets extended and everything before the start of the current JSON value gets cut. In case the masker does not process a JSON value, the buffer gets replaced with the next one.  

For writes, BufferedMaskingState flushes prepared replacement operations byte array into provided output stream. In case the data is flushed while the masker is still processing the current JSON value, everything after the start of the current value gets cut in the output byte array.  

The PR adds an assertion to every test that the output of bytes API and streams API is equivalent. There is also a disabled test that creates a ~1GB file and asserts that the masker is able to process it with streams API without going OOM.

The PR also creates StreamsBenchmark JMH suite. Those should only be used to compare performance for different types of streams as they have a specific JMH setup which has some timing measurement implications.