### PR TITLE
Replace unknown character that crashes Gradle JavaDoc generation task

### DIFF
--- a/src/main/java/dev/blaauwendraad/masker/json/ValueMaskers.java
+++ b/src/main/java/dev/blaauwendraad/masker/json/ValueMaskers.java
@@ -417,9 +417,9 @@ public final class ValueMaskers {
                                                     }
                                                 }
                                                 if (codePoint < 0) {
-                                                    // default String behaviour is to replace invalid surrogate pairs
-                                                    // with the character '�', but from the JSON perspective,
-                                                    // it's better to throw an InvalidJsonException
+                                                    // default String behaviour is to replace invalid surrogate pairs with the "replacement character"
+                                                    // (https://en.wikipedia.org/wiki/Specials_(Unicode_block)#Replacement_character)
+                                                    // but from the JSON perspective, it's better to throw an InvalidJsonException
                                                     throw context.invalidJson("Invalid surrogate pair '%s'"
                                                             .formatted(context.asString(valueStartIndex, encodedIndex - valueStartIndex)), valueStartIndex);
                                                 } else {


### PR DESCRIPTION
This change is needed because that character is not supported in JavaDoc so the Gradle `javadoc` task won't work. Like this, it does work. See https://json-masker.blaauwendraad.dev/