### PR TITLE
Reimplement multi-release jar support

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -21,4 +21,3 @@ nexus-publish = { id = "io.github.gradle-nexus.publish-plugin", version = "2.0.0
 test-logger = { id = "com.adarshr.test-logger", version = "4.0.0" }
 sonarqube = { id = "org.sonarqube", version = "6.0.1.5171" }
 errorprone = { id = "net.ltgt.errorprone", version = "4.1.0" }
-mrjar = { id = "me.champeau.mrjar", version = "0.1.1" }


### PR DESCRIPTION
Compared the jars to 1.1.1 from Maven Central - `.jar` is identical, `-sources.jar` now contains source files under `META-INF/versions/17`. After importing sources jar from IDEA it now correctly displays sources instead of complaining
![image](https://github.com/user-attachments/assets/0d1bd60b-2488-4586-ba22-5891c0174629)



Fixes #219