### PR TITLE
Fix Java 11 compatibility: replace Stream.toList() and use --release flag

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -179,13 +179,11 @@ sonar {
 
 tasks {
     compileJava {
-        sourceCompatibility = "11"
-        targetCompatibility = "11"
+        options.release = 11
     }
 
     named<JavaCompile>("compileJava17Java") {
-        sourceCompatibility = "17"
-        targetCompatibility = "17"
+        options.release = 17
     }
 
     check {

--- a/src/main/java/dev/blaauwendraad/masker/json/path/JsonPathParser.java
+++ b/src/main/java/dev/blaauwendraad/masker/json/path/JsonPathParser.java
@@ -5,6 +5,7 @@ import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 import org.jspecify.annotations.Nullable;
 
 /**
@@ -152,7 +153,7 @@ public class JsonPathParser {
     public void checkAmbiguity(Set<JsonPath> jsonPaths) {
         List<JsonPath> jsonPathList = jsonPaths.stream()
                 .sorted(Comparator.comparing(JsonPath::toString))
-                .toList();
+                .collect(Collectors.toList());
         for (int i = 1; i < jsonPathList.size(); i++) {
             JsonPath current = jsonPathList.get(i - 1);
             JsonPath next = jsonPathList.get(i);


### PR DESCRIPTION
## Problem

`JsonPathParser` in the base source set (`src/main/java`, targeting Java 11) uses `Stream.toList()`, which was introduced in Java 16. Since the MRJAR only contains `META-INF/versions/17/` entries for other classes (not `JsonPathParser`), the JVM loads the base class on Java 11–15 and throws `NoSuchMethodError` at runtime.

The root cause is that the build used `sourceCompatibility`/`targetCompatibility` instead of `--release`, which only controls bytecode version but does **not** enforce API-level compatibility.

## Fix

1. **`JsonPathParser.java`**: Replace `Stream.toList()` (Java 16+) with `Collectors.toList()` (Java 8+).
2. **`build.gradle.kts`**: Replace `sourceCompatibility`/`targetCompatibility` with `options.release` for both `compileJava` (11) and `compileJava17Java` (17). The `--release` flag tells `javac` to compile against the target JDK's API surface, so any future use of post-Java-11 APIs in the base source set will **fail at compile time**.

## Verification

- With only the `build.gradle.kts` change applied (guard enabled, but `.toList()` still present), `./gradlew compileJava` fails with:
  ```
  error: cannot find symbol
      .toList();
      ^
    symbol:   method toList()
    location: interface Stream<JsonPath>
  ```
- After applying both changes, `./gradlew clean compileJava` passes.

Fixes #320