### PR TITLE
Fix JSONPath ambiguity check in ALLOW mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # JSON Masker
 
-### Blazingly fast, zero-dependency JSON masking for Java
+### High performance, zero-dependency JSON masking for Java
 
 [![Maven Central](https://img.shields.io/maven-central/v/dev.blaauwendraad/json-masker?style=flat-square)](https://central.sonatype.com/artifact/dev.blaauwendraad/json-masker)
 [![Javadoc](https://javadoc.io/badge2/dev.blaauwendraad/json-masker/javadoc.svg?style=flat-square)](https://javadoc.io/doc/dev.blaauwendraad/json-masker)

--- a/src/main/java/dev/blaauwendraad/masker/json/config/JsonMaskingConfig.java
+++ b/src/main/java/dev/blaauwendraad/masker/json/config/JsonMaskingConfig.java
@@ -31,6 +31,11 @@ public final class JsonMaskingConfig {
     int bufferSize = 8192;
 
     private final KeyMaskingConfig defaultConfig;
+    /**
+     * Per-key masking configuration overrides. The map key is either a plain key name (e.g. {@code "ssn"}) or a
+     * JSONPath string representation (e.g. {@code "$.a.b.c"}). JSONPath entries are distinguishable by being valid
+     * JSONPath expressions (starting with {@code $}).
+     */
     private final Map<String, KeyMaskingConfig> targetKeyConfigs;
 
     JsonMaskingConfig(JsonMaskingConfig.Builder builder) {
@@ -150,6 +155,12 @@ public final class JsonMaskingConfig {
         private Boolean caseSensitiveTargetKeys;
 
         private final KeyMaskingConfig.Builder defaultConfigBuilder = KeyMaskingConfig.builder();
+        /**
+         * Per-key masking configuration overrides, keyed by plain key name (e.g. {@code "ssn"}) or JSONPath string
+         * (e.g. {@code "$.a.b.c"}). Populated by {@code maskKeys(key, config)} and {@code maskJsonPaths(path, config)}.
+         * In ALLOW mode, this is the only place where JSONPaths from {@code maskJsonPaths(path, config)} are stored
+         * (they are not added to {@link #targetJsonPaths}).
+         */
         private final Map<String, KeyMaskingConfig> targetKeyConfigs = new HashMap<>();
 
         private Builder() {}
@@ -548,7 +559,16 @@ public final class JsonMaskingConfig {
          * @return the new instance
          */
         public JsonMaskingConfig build() {
-            JSON_PATH_PARSER.checkAmbiguity(targetJsonPaths);
+            // In ALLOW mode, maskJsonPaths(path, config) only stores entries in targetKeyConfigs,
+            // so merge those JSONPaths into the ambiguity check.
+            Set<JsonPath> allJsonPaths = new HashSet<>(targetJsonPaths);
+            for (String key : targetKeyConfigs.keySet()) {
+                JsonPath parsed = JSON_PATH_PARSER.tryParse(key);
+                if (parsed != null) {
+                    allJsonPaths.add(parsed);
+                }
+            }
+            JSON_PATH_PARSER.checkAmbiguity(allJsonPaths);
             return new JsonMaskingConfig(this);
         }
     }

--- a/src/main/java/dev/blaauwendraad/masker/json/config/JsonMaskingConfig.java
+++ b/src/main/java/dev/blaauwendraad/masker/json/config/JsonMaskingConfig.java
@@ -162,6 +162,12 @@ public final class JsonMaskingConfig {
          * (they are not added to {@link #targetJsonPaths}).
          */
         private final Map<String, KeyMaskingConfig> targetKeyConfigs = new HashMap<>();
+        /**
+         * Tracks JSONPaths added via {@code maskJsonPaths(path, config)} for the ambiguity check in {@link #build()}.
+         * In ALLOW mode these are not added to {@link #targetJsonPaths}, so this set ensures they are still included in
+         * the ambiguity validation.
+         */
+        private final Set<JsonPath> customConfigJsonPaths = new HashSet<>();
 
         private Builder() {}
 
@@ -318,6 +324,7 @@ public final class JsonMaskingConfig {
             }
             if (config != null) {
                 targetKeyConfigs.put(parsed.toString(), config);
+                customConfigJsonPaths.add(parsed);
             }
         }
 
@@ -559,15 +566,8 @@ public final class JsonMaskingConfig {
          * @return the new instance
          */
         public JsonMaskingConfig build() {
-            // In ALLOW mode, maskJsonPaths(path, config) only stores entries in targetKeyConfigs,
-            // so merge those JSONPaths into the ambiguity check.
             Set<JsonPath> allJsonPaths = new HashSet<>(targetJsonPaths);
-            for (String key : targetKeyConfigs.keySet()) {
-                JsonPath parsed = JSON_PATH_PARSER.tryParse(key);
-                if (parsed != null) {
-                    allJsonPaths.add(parsed);
-                }
-            }
+            allJsonPaths.addAll(customConfigJsonPaths);
             JSON_PATH_PARSER.checkAmbiguity(allJsonPaths);
             return new JsonMaskingConfig(this);
         }

--- a/src/test/java/dev/blaauwendraad/masker/json/config/JsonMaskingConfigTest.java
+++ b/src/test/java/dev/blaauwendraad/masker/json/config/JsonMaskingConfigTest.java
@@ -84,6 +84,13 @@ final class JsonMaskingConfigTest {
                         .maskBooleansWith(false),
                 () -> JsonMaskingConfig.builder()
                         .maskBooleansWith(ValueMaskers.with(false))
-                        .maskBooleansWith(ValueMaskers.with(false)));
+                        .maskBooleansWith(ValueMaskers.with(false)),
+                () -> JsonMaskingConfig.builder()
+                        .allowJsonPaths("$.a.b.c")
+                        .maskJsonPaths("$.a.*.c", KeyMaskingConfig.builder().build()),
+                () -> JsonMaskingConfig.builder()
+                        .allowJsonPaths("$.x.y")
+                        .maskJsonPaths("$.a.*.c", KeyMaskingConfig.builder().build())
+                        .maskJsonPaths("$.a.b.c", KeyMaskingConfig.builder().build()));
     }
 }

--- a/src/test/java/dev/blaauwendraad/masker/json/config/JsonMaskingConfigTest.java
+++ b/src/test/java/dev/blaauwendraad/masker/json/config/JsonMaskingConfigTest.java
@@ -7,6 +7,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
@@ -92,5 +93,23 @@ final class JsonMaskingConfigTest {
                         .allowJsonPaths("$.x.y")
                         .maskJsonPaths("$.a.*.c", KeyMaskingConfig.builder().build())
                         .maskJsonPaths("$.a.b.c", KeyMaskingConfig.builder().build()));
+    }
+
+    @ParameterizedTest
+    @MethodSource("validBuilders")
+    void validBuilders(Supplier<JsonMaskingConfig.Builder> builder) {
+        Assertions.assertDoesNotThrow(() -> builder.get().build());
+    }
+
+    private static Stream<Supplier<JsonMaskingConfig.Builder>> validBuilders() {
+        return Stream.of(
+                // non-ambiguous allowJsonPaths + maskJsonPaths with config
+                () -> JsonMaskingConfig.builder()
+                        .allowJsonPaths("$.a.b.c")
+                        .maskJsonPaths("$.d.e.f", KeyMaskingConfig.builder().build()),
+                // plain keys with maskKeys config in ALLOW mode should not be affected
+                () -> JsonMaskingConfig.builder()
+                        .allowKeys("name")
+                        .maskKeys("ssn", KeyMaskingConfig.builder().build()));
     }
 }


### PR DESCRIPTION
## Problem

In ALLOW mode, JSONPaths added via `maskJsonPaths(path, KeyMaskingConfig)` are stored only in `targetKeyConfigs` (not in `targetJsonPaths`). Since `build()` only called `checkAmbiguity(targetJsonPaths)`, these paths were never validated for ambiguity — neither against each other, nor against `allowJsonPaths` entries.

For example, this config should throw but didn't:
```java
JsonMaskingConfig.builder()
    .allowJsonPaths("$.a.b.c")
    .maskJsonPaths("$.a.*.c", KeyMaskingConfig.builder().build())
    .build() // should throw: ambiguity between $.a.b.c and $.a.*.c
```

## Fix

- **`JsonMaskingConfig.build()`**: Merge JSONPath entries from `targetKeyConfigs` (using `tryParse` to skip plain key names) into the ambiguity check set before calling `checkAmbiguity`.
- **Javadoc**: Added documentation to `targetKeyConfigs` (both outer class and builder fields) clarifying that it contains both plain key names and JSONPath strings.
- **Tests**: Added two test cases to `JsonMaskingConfigTest.invalidBuilders()`:
  1. Ambiguity between `allowJsonPaths` and `maskJsonPaths(path, config)`
  2. Ambiguity between two `maskJsonPaths(path, config)` calls in ALLOW mode
- **README**: Minor wording update.

Fixes #318